### PR TITLE
Update Go version and dependencies in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
       - name: Display Go version
         run: go version
       - name: Code Lint
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea
         with:
-          version: v1.61.0
+          version: v1.64.7
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/make-it-public
 
-go 1.23.4
+go 1.24.1
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
### Changes Made
- Updated Go version to `1.24.x` in GitHub Actions workflow.
- Set Go version to `1.24.1` in `go.mod` file.
- Upgraded `golangci-lint-action` to version `1.64.7`.

### Purpose
These updates ensure compatibility with the latest Go version, improve consistency, and align with recent changes.