### PR TITLE
Refactor server arguments and implement flexible logger setup

### DIFF
--- a/pkg/cmd/server/config.go
+++ b/pkg/cmd/server/config.go
@@ -21,9 +21,9 @@ type revProxyConfig struct {
 }
 
 // loadConfig loads the application configuration from the specified file path and environment variables.
-// It uses the provided flags structure to determine the configuration path.
+// It uses the provided args structure to determine the configuration path.
 // The function returns a pointer to the appConfig structure and an error if something goes wrong.
-func loadConfig(arg *flags) (*appConfig, error) {
+func loadConfig(arg *args) (*appConfig, error) {
 	v := viper.New()
 
 	v.SetConfigFile(arg.configPath)

--- a/pkg/cmd/server/config_test.go
+++ b/pkg/cmd/server/config_test.go
@@ -82,11 +82,11 @@ reverse_proxy:
 				}
 			}
 
-			args := &flags{
+			arg := &args{
 				configPath: configPath,
 			}
 
-			cfg, err := loadConfig(args)
+			cfg, err := loadConfig(arg)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/cmd/server/logger.go
+++ b/pkg/cmd/server/logger.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"log/slog"
+	"os"
+)
+
+// initLogger initializes the default logger for the application using slog.
+// It does not take any parameters.
+// It returns an error if the logger initialization fails, although in this implementation, it always returns nil.
+func initLogger(arg *args) error {
+	var logLever slog.Level
+	if err := logLever.UnmarshalText([]byte(arg.logLevel)); err != nil {
+		return err
+	}
+
+	options := &slog.HandlerOptions{
+		Level: logLever,
+	}
+
+	var logHandler slog.Handler
+	if arg.textFormat {
+		logHandler = slog.NewTextHandler(os.Stdout, options)
+	} else {
+		logHandler = slog.NewJSONHandler(os.Stdout, options)
+	}
+
+	logger := slog.New(logHandler).With(
+		slog.String("ver", arg.version),
+		slog.String("app", "make-it-public"),
+	)
+
+	slog.SetDefault(logger)
+
+	return nil
+}

--- a/pkg/cmd/server/logger_test.go
+++ b/pkg/cmd/server/logger_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     args
+		wantErr bool
+	}{
+		{
+			name: "Valid log level with text format",
+			arg: args{
+				logLevel:   "info",
+				textFormat: true,
+				version:    "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid log level with JSON format",
+			arg: args{
+				logLevel:   "debug",
+				textFormat: false,
+				version:    "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid log level",
+			arg: args{
+				logLevel:   "invalid",
+				textFormat: true,
+				version:    "1.0.0",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := tt.arg
+			err := initLogger(&args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -14,13 +14,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type flags struct {
+type args struct {
 	configPath string
+	logLevel   string
+	textFormat bool
+	version    string
 }
 
-// InitCommand initializes and returns a cobra.Command for running the server with configurable flags.
+// InitCommand initializes and returns a cobra.Command for running the server with configurable args.
 func InitCommand() cobra.Command {
-	args := flags{}
+	args := args{}
 
 	cmd := cobra.Command{
 		Use:   "server",
@@ -31,14 +34,20 @@ func InitCommand() cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&args.configPath, "config", "runtime/config.yaml", "config path")
+	cmd.Flags().StringVar(&args.logLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	cmd.Flags().BoolVar(&args.textFormat, "log-text", false, "log in text format, otherwise JSON")
 
 	return cmd
 }
 
 // RunServerCommand initializes and starts both reverse proxy and HTTP servers for handling client connections.
-// It takes ctx of type context.Context for managing the server lifecycle and args of type *flags to load configuration.
+// It takes ctx of type context.Context for managing the server lifecycle and args of type *args to load configuration.
 // It returns an error if the configuration fails to load, servers cannot start, or any runtime error occurs.
-func RunServerCommand(ctx context.Context, args *flags) error {
+func RunServerCommand(ctx context.Context, args *args) error {
+	if err := initLogger(args); err != nil {
+		return fmt.Errorf("failed to init logger: %w", err)
+	}
+
 	cfg, err := loadConfig(args)
 	if err != nil {
 		return fmt.Errorf("failed to loag config: %w", err)


### PR DESCRIPTION
### Description

- Refactored server command-line arguments by replacing `flags` with an `args` struct, now supporting logging configuration.
- Added an `initLogger` function for flexible logger setup, enabling text or JSON formats and configurable log levels.
- Updated related server code to accommodate the new structure.
- Added unit tests to ensure proper logger initialization and robustness.