### PR TITLE
Refactor and centralize error handling for failed connections

### DIFF
--- a/pkg/core/connsvc/svc.go
+++ b/pkg/core/connsvc/svc.go
@@ -77,7 +77,7 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, userID string, conn 
 
 	ch, err := s.connmng.RequestConnection(ctx, userID)
 	if err != nil {
-		return errors.Join(core.ErrFailedToConnect, err)
+		return core.ErrFailedToConnect
 	}
 
 	select {

--- a/pkg/core/connsvc/svc.go
+++ b/pkg/core/connsvc/svc.go
@@ -9,11 +9,10 @@ import (
 	"net"
 
 	"github.com/google/uuid"
+	"github.com/ksysoev/make-it-public/pkg/core"
 	"github.com/ksysoev/revdial/proto"
 	"golang.org/x/sync/errgroup"
 )
-
-var ErrFailedToConnect = errors.New("failed to connect")
 
 type AuthRepo interface {
 	Verify(user, pass string) bool
@@ -78,15 +77,15 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, userID string, conn 
 
 	ch, err := s.connmng.RequestConnection(ctx, userID)
 	if err != nil {
-		return errors.Join(ErrFailedToConnect, err)
+		return errors.Join(core.ErrFailedToConnect, err)
 	}
 
 	select {
 	case <-ctx.Done():
-		return errors.Join(ErrFailedToConnect, ctx.Err())
+		return errors.Join(core.ErrFailedToConnect, ctx.Err())
 	case revConn, ok := <-ch:
 		if !ok {
-			return errors.Join(fmt.Errorf("connection request failed"), ErrFailedToConnect)
+			return errors.Join(fmt.Errorf("connection request failed"), core.ErrFailedToConnect)
 		}
 
 		defer func() {

--- a/pkg/core/connsvc/svc.go
+++ b/pkg/core/connsvc/svc.go
@@ -101,8 +101,6 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, userID string, conn 
 		eg.Go(func() error {
 			<-ctx.Done()
 
-			_ = cliConn.Close()
-
 			return revConn.Close()
 		})
 

--- a/pkg/core/connsvc/svc_test.go
+++ b/pkg/core/connsvc/svc_test.go
@@ -81,12 +81,11 @@ func TestHandleHTTPConnection_WriteError(t *testing.T) {
 	defer cancel()
 
 	writeFunc := func(_ net.Conn) error {
-		return errors.New("write error")
+		return assert.AnError
 	}
 
 	err := service.HandleHTTPConnection(ctx, "test-user", clientConn, writeFunc)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to write initial request: write error")
+	assert.ErrorIs(t, err, core.ErrFailedToConnect)
 }
 
 func TestHandleHTTPConnection_ContextCancellation(t *testing.T) {
@@ -103,5 +102,5 @@ func TestHandleHTTPConnection_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	err := service.HandleHTTPConnection(ctx, "test-user", clientConn, func(net.Conn) error { return nil })
-	require.ErrorIs(t, err, core.ErrFailedToConnect)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/pkg/core/connsvc/svc_test.go
+++ b/pkg/core/connsvc/svc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ksysoev/make-it-public/pkg/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -61,8 +62,7 @@ func TestHandleHTTPConnection_ConnectionRequestFailure(t *testing.T) {
 	defer cancel()
 
 	err := service.HandleHTTPConnection(ctx, "test-user", clientConn, func(net.Conn) error { return nil })
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to request connection: connection failed")
+	require.ErrorIs(t, err, core.ErrFailedToConnect)
 }
 
 func TestHandleHTTPConnection_WriteError(t *testing.T) {
@@ -103,6 +103,5 @@ func TestHandleHTTPConnection_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	err := service.HandleHTTPConnection(ctx, "test-user", clientConn, func(net.Conn) error { return nil })
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	require.ErrorIs(t, err, core.ErrFailedToConnect)
 }

--- a/pkg/core/context_reader.go
+++ b/pkg/core/context_reader.go
@@ -16,6 +16,10 @@ type ContextConnNopCloser struct {
 	cancel context.CancelFunc
 }
 
+// NewContextConnNopCloser wraps a net.Conn with a context-aware layer and a no-op Close implementation.
+// It creates a new ContextConnNopCloser that ensures read methods respect the provided context's cancellation.
+// Accepts ctx the context to manage cancellation and conn the underlying network connection.
+// Returns a ContextConnNopCloser that integrates context cancellation with the provided connection's lifecycle.
 func NewContextConnNopCloser(ctx context.Context, conn net.Conn) *ContextConnNopCloser {
 	ctx, cancel := context.WithCancel(ctx)
 	return &ContextConnNopCloser{
@@ -25,6 +29,8 @@ func NewContextConnNopCloser(ctx context.Context, conn net.Conn) *ContextConnNop
 	}
 }
 
+// Read reads up to len(p) bytes into p, respecting the context's deadline and cancellation.
+// It returns the number of bytes read and an error if reading fails or the context is canceled.
 func (c *ContextConnNopCloser) Read(p []byte) (int, error) {
 	if c.ctx.Err() != nil {
 		return 0, c.ctx.Err()
@@ -53,6 +59,9 @@ func (c *ContextConnNopCloser) Read(p []byte) (int, error) {
 	}
 }
 
+// Close cancels the context associated with the connection and releases its resources.
+// It ensures cleanup of the context's state and prevents further operations that rely on the context.
+// Returns an error only if any issues occur during the cancellation process, though typically nil.
 func (c *ContextConnNopCloser) Close() error {
 	c.cancel()
 

--- a/pkg/core/context_reader.go
+++ b/pkg/core/context_reader.go
@@ -22,6 +22,7 @@ type ContextConnNopCloser struct {
 // Returns a ContextConnNopCloser that integrates context cancellation with the provided connection's lifecycle.
 func NewContextConnNopCloser(ctx context.Context, conn net.Conn) *ContextConnNopCloser {
 	ctx, cancel := context.WithCancel(ctx)
+
 	return &ContextConnNopCloser{
 		Conn:   conn,
 		ctx:    ctx,
@@ -43,7 +44,7 @@ func (c *ContextConnNopCloser) Read(p []byte) (int, error) {
 			deadline = ctxDeadline
 		}
 
-		if err := c.Conn.SetReadDeadline(deadline); err != nil {
+		if err := c.SetReadDeadline(deadline); err != nil {
 			return 0, err
 		}
 
@@ -62,7 +63,6 @@ func (c *ContextConnNopCloser) Read(p []byte) (int, error) {
 		default:
 			return n, err
 		}
-
 	}
 
 	return n, c.ctx.Err()

--- a/pkg/core/context_reader.go
+++ b/pkg/core/context_reader.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"time"
+)
+
+const interval = 10 * time.Millisecond
+
+type ContextConnNopCloser struct {
+	net.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewContextConnNopCloser(ctx context.Context, conn net.Conn) *ContextConnNopCloser {
+	ctx, cancel := context.WithCancel(ctx)
+	return &ContextConnNopCloser{
+		Conn:   conn,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (c *ContextConnNopCloser) Read(p []byte) (int, error) {
+	if c.ctx.Err() != nil {
+		return 0, c.ctx.Err()
+	}
+
+	deadline := time.Now().Add(interval)
+
+	ctxDeadline, ok := c.ctx.Deadline()
+
+	if ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+
+	if err := c.Conn.SetReadDeadline(deadline); err != nil {
+		return 0, err
+	}
+
+	n, err := c.Conn.Read(p)
+	switch {
+	case err == nil:
+		return n, nil
+	case errors.Is(err, os.ErrDeadlineExceeded):
+		return n, nil
+	default:
+		return n, err
+	}
+}
+
+func (c *ContextConnNopCloser) Close() error {
+	c.cancel()
+
+	return nil
+}

--- a/pkg/core/context_reader_test.go
+++ b/pkg/core/context_reader_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConn struct {
+	mock.Mock
+}
+
+func (m *MockConn) Read(b []byte) (int, error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConn) Write(b []byte) (int, error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConn) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockConn) LocalAddr() net.Addr {
+	args := m.Called()
+	return args.Get(0).(net.Addr)
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	args := m.Called()
+	return args.Get(0).(net.Addr)
+}
+
+func (m *MockConn) SetDeadline(t time.Time) error {
+	args := m.Called(t)
+	return args.Error(0)
+}
+
+func (m *MockConn) SetReadDeadline(t time.Time) error {
+	args := m.Called(t)
+	return args.Error(0)
+}
+
+func (m *MockConn) SetWriteDeadline(t time.Time) error {
+	args := m.Called(t)
+	return args.Error(0)
+}
+
+func TestRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
+	mockConn.On("Read", mock.Anything).Return(0, errors.New("read error"))
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+	cancel()
+
+	_, err := conn.Read(make([]byte, 10))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRespectsContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
+	mockConn.On("Read", mock.Anything).Return(0, os.ErrDeadlineExceeded)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	time.Sleep(60 * time.Millisecond)
+	_, err := conn.Read(make([]byte, 10))
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestReturnsDataWhenReadSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
+	mockConn.On("Read", mock.Anything).Return(5, nil)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	data := make([]byte, 10)
+	n, err := conn.Read(data)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+}
+
+func TestCloseCancelsContext(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	mockConn.On("Close").Return(nil)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	_ = conn.Close()
+	assert.ErrorIs(t, conn.ctx.Err(), context.Canceled)
+}
+
+func TestHandlesSetReadDeadlineError(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	expectedErr := errors.New("deadline setting error")
+	mockConn.On("SetReadDeadline", mock.Anything).Return(expectedErr)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	_, err := conn.Read(make([]byte, 10))
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestContinuesReadingAfterDeadlineExceeded(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
+	mockConn.On("Read", mock.Anything).Return(0, os.ErrDeadlineExceeded).Once()
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	data := make([]byte, 10)
+	n, err := conn.Read(data)
+	assert.Equal(t, 0, n)
+	assert.NoError(t, err)
+}
+
+func TestUsesContextDeadlineWhenAvailable(t *testing.T) {
+	deadline := time.Now().Add(5 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", deadline).Return(nil)
+	mockConn.On("Read", mock.Anything).Return(3, nil)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	n, err := conn.Read(make([]byte, 10))
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+	mockConn.AssertCalled(t, "SetReadDeadline", deadline)
+}
+
+func TestUsesDefaultDeadlineWhenNoContextDeadline(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		deadline := args.Get(0).(time.Time)
+		expectedMinDeadline := time.Now().Add(interval - time.Millisecond)
+		assert.True(t, deadline.After(expectedMinDeadline))
+	})
+	mockConn.On("Read", mock.Anything).Return(3, nil)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	_, err := conn.Read(make([]byte, 10))
+	assert.NoError(t, err)
+}
+
+func TestReturnsTrueErrorFromRead(t *testing.T) {
+	ctx := context.Background()
+
+	mockConn := new(MockConn)
+	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
+	expectedErr := errors.New("connection reset")
+	mockConn.On("Read", mock.Anything).Return(0, expectedErr)
+
+	conn := NewContextConnNopCloser(ctx, mockConn)
+
+	_, err := conn.Read(make([]byte, 10))
+	assert.ErrorIs(t, err, expectedErr)
+}

--- a/pkg/core/context_reader_test.go
+++ b/pkg/core/context_reader_test.go
@@ -131,13 +131,13 @@ func TestContinuesReadingAfterDeadlineExceeded(t *testing.T) {
 
 	mockConn := new(MockConn)
 	mockConn.On("SetReadDeadline", mock.Anything).Return(nil)
-	mockConn.On("Read", mock.Anything).Return(0, os.ErrDeadlineExceeded).Once()
+	mockConn.On("Read", mock.Anything).Return(10, os.ErrDeadlineExceeded).Once()
 
 	conn := NewContextConnNopCloser(ctx, mockConn)
 
 	data := make([]byte, 10)
 	n, err := conn.Read(data)
-	assert.Equal(t, 0, n)
+	assert.Equal(t, 10, n)
 	assert.NoError(t, err)
 }
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,0 +1,5 @@
+package core
+
+import "errors"
+
+var ErrFailedToConnect = errors.New("failed to connect")

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -96,8 +96,15 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case errors.Is(core.ErrFailedToConnect, err):
-		slog.DebugContext(ctx, "failed to handle connection", slog.Any("error", err))
-		http.Error(w, "Failed to handle connection: "+err.Error(), http.StatusBadGateway)
+		resp := &http.Response{
+			Status:     "502 Bad Gateway",
+			StatusCode: http.StatusBadGateway,
+			Proto:      r.Proto,
+			ProtoMajor: r.ProtoMajor,
+			ProtoMinor: r.ProtoMinor,
+		}
+
+		_ = resp.Write(clientConn)
 	case err != nil:
 		slog.ErrorContext(ctx, "failed to handle connection", slog.Any("error", err))
 		http.Error(w, "Failed to handle connection: "+err.Error(), http.StatusInternalServerError)

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -63,7 +63,7 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID := s.getUserIDFromHeader(r)
+	userID := s.getUserIDFromRequest(r)
 	if userID == "" {
 		http.Error(w, "invalid or missing subdomain", http.StatusBadRequest)
 
@@ -100,10 +100,10 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getUserIDFromHeader extracts the subdomain from the host in the HTTP request.
+// getUserIDFromRequest extracts the subdomain from the host in the HTTP request.
 // It assumes the host follows the subdomain.domain.tld format.
 // Returns the subdomain as a string or an empty string if no subdomain exists.
-func (s *HTTPServer) getUserIDFromHeader(r *http.Request) string {
+func (s *HTTPServer) getUserIDFromRequest(r *http.Request) string {
 	host := r.Host
 
 	if host != "" {

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -105,6 +105,9 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		_ = resp.Write(clientConn)
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		slog.DebugContext(ctx, "connection timed out", slog.String("host", r.Host))
+		return
 	case err != nil:
 		slog.ErrorContext(ctx, "failed to handle connection", slog.Any("error", err))
 		http.Error(w, "Failed to handle connection: "+err.Error(), http.StatusInternalServerError)

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -95,7 +95,7 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 
 	switch {
-	case errors.Is(core.ErrFailedToConnect, err), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	case errors.Is(err, core.ErrFailedToConnect):
 		resp := &http.Response{
 			Status:     "502 Bad Gateway",
 			StatusCode: http.StatusBadGateway,

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -111,8 +111,6 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case err != nil:
 		slog.ErrorContext(ctx, "failed to handle connection", slog.Any("error", err))
 		http.Error(w, "Failed to handle connection: "+err.Error(), http.StatusInternalServerError)
-	default:
-		slog.DebugContext(ctx, "connection handled successfully", slog.String("host", r.Host))
 	}
 }
 

--- a/pkg/edge/httpserver_test.go
+++ b/pkg/edge/httpserver_test.go
@@ -30,7 +30,7 @@ func TestGetUserIDFromHeader(t *testing.T) {
 			server := &HTTPServer{}
 
 			// Act
-			result := server.getUserIDFromHeader(req)
+			result := server.getUserIDFromRequest(req)
 
 			// Assert
 			assert.Equal(t, tt.expected, result)


### PR DESCRIPTION
### Description

This pull request refactors error handling and introduces a centralized error for connection failures. Changes include:

- Introduced `ErrFailedToConnect` in the `core` package, replacing duplicate error definitions to enhance maintainability.
- Updated connection error handling with `errors.Join` for better error composition.
- Renamed `getUserIDFromHeader` to `getUserIDFromRequest` for clarity.
- Ensured consistent and proper HTTP response construction in connection failure scenarios.
- Adjusted related tests to align with these changes.

These improvements enhance code clarity, consistency, and error-handling practices.