### PR TITLE
Update Dockerfile and enhance command flag handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY ./runtime/config.yaml /runtime/config.yaml
 
 EXPOSE 8080 8081 8082
 
-CMD ["./mitserver", "serve", "all", "config", "/runtime/config.yaml"]
+ENTRYPOINT ["/mitserver"]
+CMD ["serve", "all", "--config", "runtime/config.yaml"]

--- a/pkg/cmd/server/init.go
+++ b/pkg/cmd/server/init.go
@@ -26,9 +26,9 @@ func InitCommand() cobra.Command {
 	cmd.AddCommand(InitServeCommand(&arg))
 	cmd.AddCommand(InitTokenCommand(&arg))
 
-	cmd.Flags().StringVar(&arg.configPath, "config", "runtime/config.yaml", "config path")
-	cmd.Flags().StringVar(&arg.logLevel, "log-level", "info", "log level (debug, info, warn, error)")
-	cmd.Flags().BoolVar(&arg.textFormat, "log-text", false, "log in text format, otherwise JSON")
+	cmd.PersistentFlags().StringVar(&arg.configPath, "config", "runtime/config.yaml", "config path")
+	cmd.PersistentFlags().StringVar(&arg.logLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	cmd.PersistentFlags().BoolVar(&arg.textFormat, "log-text", false, "log in text format, otherwise JSON")
 
 	return cmd
 }


### PR DESCRIPTION
### Description
- Replaced `CMD` with `ENTRYPOINT` in the Dockerfile for improved flexibility in command execution.
- Adjusted `CMD` arguments for better usability.
- Switched to `PersistentFlags` in server initialization to allow flag availability across subcommands, enhancing consistency.
