### PR TITLE
Enable push trigger for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,15 +4,10 @@ permissions:
   contents: read
 
 on:
-#    push:
-#        branches:
-#        - main
-#        tags:
-#        - v*
-#    pull_request:
-#
-    workflow_dispatch:
-
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
The deployment workflow has been updated to run on `push` events to the main branch. This complements the existing `workflow_dispatch` trigger, enabling automatic deployment for updates to the main branch. This change streamlines the deployment process by reducing manual intervention.