### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - v*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request modifies the deployment workflow configuration to trigger deployments based on version tags instead of pushes to the `main` branch.

Workflow configuration changes:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L8-R9): Updated the `on` section to trigger the workflow on tags matching the pattern `v*` instead of on pushes to the `main` branch.