### PR TITLE
Add TTL support in token generation and enhance tests

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -118,17 +118,19 @@ func initTokenCommand(arg *args) *cobra.Command {
 	}
 
 	keyID := ""
+	var keyTTL int
 
 	cmdGenerateToken := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a new token",
 		Long:  "Generate a new token for authentication.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return RunGenerateToken(cmd.Context(), arg, keyID)
+			return RunGenerateToken(cmd.Context(), arg, keyID, keyTTL)
 		},
 	}
 
 	cmdGenerateToken.Flags().StringVar(&keyID, "key-id", "", "Key ID for the token")
+	cmdGenerateToken.Flags().IntVar(&keyTTL, "ttl", 1, "Token time to live in hours")
 
 	cmd.AddCommand(cmdGenerateToken)
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -117,8 +117,10 @@ func initTokenCommand(arg *args) *cobra.Command {
 		Long:  "Token management commands for the server.",
 	}
 
-	keyID := ""
-	var keyTTL int
+	var (
+		keyID  string
+		keyTTL int
+	)
 
 	cmdGenerateToken := &cobra.Command{
 		Use:   "generate",

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -40,6 +40,18 @@ func TestInitTokenCommand(t *testing.T) {
 	assert.Contains(t, cmd.Long, "commands for the server")
 
 	require.Len(t, cmd.Commands(), 1)
-	assert.Equal(t, "generate", cmd.Commands()[0].Use)
-	assert.Contains(t, cmd.Commands()[0].Short, "Generate a new token")
+	generateCmd := cmd.Commands()[0]
+	assert.Equal(t, "generate", generateCmd.Use)
+	assert.Contains(t, generateCmd.Short, "Generate a new token")
+
+	// Validate flags of the generate subcommand
+	keyIDFlag := generateCmd.Flags().Lookup("key-id")
+	require.NotNil(t, keyIDFlag)
+	assert.Equal(t, "", keyIDFlag.DefValue)
+	assert.Contains(t, keyIDFlag.Usage, "Key ID for the token")
+
+	ttlFlag := generateCmd.Flags().Lookup("ttl")
+	require.NotNil(t, ttlFlag)
+	assert.Equal(t, "1", ttlFlag.DefValue)
+	assert.Contains(t, ttlFlag.Usage, "Token time to live in hours")
 }

--- a/pkg/cmd/token.go
+++ b/pkg/cmd/token.go
@@ -11,7 +11,11 @@ import (
 // RunGenerateToken initializes the logger, loads configuration, and generates a new token for authentication.
 // It takes a context for request scoping, and args containing configuration details like path, log level, and format.
 // Returns an error if logger initialization, configuration loading, or token generation fails.
-func RunGenerateToken(ctx context.Context, args *args, keyID string) error {
+func RunGenerateToken(ctx context.Context, args *args, keyID string, keyTTL int) error {
+	if keyTTL < 1 {
+		return fmt.Errorf("key TTL must be greater than 0")
+	}
+
 	if err := initLogger(args); err != nil {
 		return fmt.Errorf("failed to init logger: %w", err)
 	}
@@ -23,7 +27,7 @@ func RunGenerateToken(ctx context.Context, args *args, keyID string) error {
 
 	authRepo := auth.New(&cfg.Auth)
 
-	token, err := authRepo.GenerateToken(ctx, keyID, time.Hour)
+	token, err := authRepo.GenerateToken(ctx, keyID, time.Duration(keyTTL)*time.Hour)
 	if err != nil {
 		return fmt.Errorf("failed to generate token: %w", err)
 	}


### PR DESCRIPTION
### Summary

- Implemented a `--ttl` flag for setting token time-to-live (TTL) in hours during token generation, with validation to ensure values are positive. Default set to 1 hour when omitted.
- Refactored and enriched tests to validate `generate` command flags, ensuring correct configuration of `key-id` and `ttl` parameters.
