### PR TITLE
Set default server address via build-time argument

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,5 +50,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ env.VERSION }}
-            BUILD=${{ github.sha }}
+            MIT_SERVER=${{ secrets.MIT_SERVER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM golang:1.24.3 AS builder
 
+ARG MIT_SERVER=${MIT_SERVER}
+
 WORKDIR /app
 
 COPY . .
 RUN go mod download
 
-RUN CGO_ENABLED=0 go build -o mit ./cmd/mit/main.go
+RUN CGO_ENABLED=0 go build -o mit -ldflags "-X main.defaultServer=$MIT_SERVER" ./cmd/mit/main.go
 
 FROM scratch
 

--- a/cmd/mit/main.go
+++ b/cmd/mit/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ksysoev/make-it-public/pkg/cmd"
 )
 
+var defaultServer = "loalhost:8081"
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 

--- a/cmd/mit/main.go
+++ b/cmd/mit/main.go
@@ -10,12 +10,14 @@ import (
 	"github.com/ksysoev/make-it-public/pkg/cmd"
 )
 
-var defaultServer = "loalhost:8081"
+var defaultServer = "localhost:8081"
 
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
-	command := cmd.InitCommand()
+	command := cmd.InitCommand(cmd.BuildInfo{
+		DefaultServer: defaultServer,
+	})
 
 	err := command.ExecuteContext(ctx)
 	if err != nil {

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -7,6 +7,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+type BuildInfo struct {
+	DefaultServer string
+}
 type args struct {
 	Server     string `mapstructure:"server"`
 	Expose     string `mapstructure:"expose"`
@@ -22,7 +25,7 @@ type args struct {
 // InitCommand initializes the root command of the CLI application with its subcommands and flags.
 // It sets up the "mit" command with pre-defined subcommands, including the "server" command.
 // Returns a cobra.Command configured with flags for setting server address, service exposure, and token authentication.
-func InitCommand() cobra.Command {
+func InitCommand(build BuildInfo) cobra.Command {
 	arg := args{}
 
 	cmd := cobra.Command{
@@ -34,8 +37,8 @@ func InitCommand() cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&arg.Server, "server", "test.com", "server address")
-	cmd.Flags().StringVar(&arg.Expose, "expose", "localhost:80", "expose service")
+	cmd.Flags().StringVar(&arg.Server, "server", build.DefaultServer, "server address")
+	cmd.Flags().StringVar(&arg.Expose, "expose", "", "expose service")
 	cmd.Flags().StringVar(&arg.Token, "token", "", "token")
 	cmd.Flags().BoolVar(&arg.NoTLS, "no-tls", false, "disable TLS")
 	cmd.Flags().BoolVar(&arg.Insecure, "insecure", false, "skip TLS verification")

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestInitCommand(t *testing.T) {
-	cmd := InitCommand()
+	cmd := InitCommand(BuildInfo{})
 
 	assert.Equal(t, "mit", cmd.Use)
 	assert.Contains(t, cmd.Short, "Make It Public")


### PR DESCRIPTION
### Summary
This pull request introduces the ability to set a default server address during the build process. A new `defaultServer` variable has been added to centralize server configuration. The Dockerfile has also been updated to pass the server address as a build-time argument using `-ldflags`, improving build-time configurability and flexibility. 

### Changes
- Added `defaultServer` variable for centralized server configuration.
- Updated Dockerfile to enable setting the server address via `-ldflags`.

