### PR TITLE
Add MIT_SERVER environment variable for runtime configurability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          MIT_SERVER: ${{ secrets.MIT_SERVER }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
       - darwin
     ldflags:
       - -s -w -X main.version={{.Version}}
+      - -s -w -X main.defaultServer={{.Env.MIT_SERVER}}
 archives:
   - name_template: >-
       {{ .ProjectName }}_
@@ -44,7 +45,7 @@ brews:
     test: |
       system "#{bin}/mit"
     install: |
-    bin.install 'mit'
+      bin.install 'mit'
 
 nfpms:
   - id: make-it-public
@@ -70,3 +71,4 @@ snapcrafts:
     apps:
       make-it-public:
         plugs: ["network", "network-bind"]
+        command: "mit"


### PR DESCRIPTION
This pull request introduces the `MIT_SERVER` environment variable:

- Updates the release workflow to include `MIT_SERVER`.
- Integrates dynamic support for the default server using `ldflags` in the build process.

These changes enhance configurability and simplify deployment flexibility by enabling runtime specification of the server.