### PR TITLE
Remove unused 'command' field from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,4 +71,3 @@ snapcrafts:
     apps:
       make-it-public:
         plugs: ["network", "network-bind"]
-        command: "mit"


### PR DESCRIPTION
This pull request removes the redundant 'command' field from the 'make-it-public' configuration in goreleaser. The change simplifies the config without affecting existing functionality.