### PR TITLE
Update docker-compose with defaults and network configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,5 @@ jobs:
             export EMAIL=${{ secrets.EMAIL }}
             export DOMAIN_NAME=${{ secrets.DOMAIN_NAME }}
             export AUTH_SALT=${{ secrets.AUTH_SALT }}
+            export NETWORK_NAME=${{ env.MIT_NETWORK }}
             docker stack deploy -c docker-compose.yml makeitpublic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - "8082:8082" # API server
     environment:
       - AUTH_REDIS_ADDR=redis:6379
-      - AUTH_SALT=${AUTH_SALT}
+      - AUTH_SALT=${AUTH_SALT:-someRandomSalt}
       - HTTP_PUBLIC_SCHEMA=https
-      - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME}
+      - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME:-make-it-public.dev}
       - HTTP_LISTEN=:8080
       - REVERSE_PROXY_LISTEN=:8081
       - REVERSE_PROXY_CERT=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${DOMAIN_NAME}/${DOMAIN_NAME}.crt
@@ -32,6 +32,8 @@ services:
     command: ["server", "run", "all" ]
     volumes:
       - caddy_data:/data:ro
+    networks:
+      - mit-network
     depends_on:
       - redis
 
@@ -60,3 +62,8 @@ services:
 volumes:
   caddy_data:
   caddy_config:
+
+networks:
+  public:
+    external:
+      name: mit-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     image: docker.io/bitnami/redis:7.4.2
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - redis_data:/bitnami/redis/data
+    networks:
+      - mit-network
     ports:
       - "6379"
 
@@ -58,12 +62,15 @@ services:
       - caddy_config:/config
     depends_on:
       - mitserver
+    networks:
+      - mit-network
 
 volumes:
   caddy_data:
   caddy_config:
+  redis_data:
 
 networks:
-  public:
-    external:
-      name: mit-network
+  mit-network:
+    external: true
+    name: ${NETWORK_NAME:-mit-network}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     volumes:
       - redis_data:/bitnami/redis/data
-    networks:
-      - mit-network
     ports:
       - "6379"
 
@@ -36,8 +34,6 @@ services:
     command: ["server", "run", "all" ]
     volumes:
       - caddy_data:/data:ro
-    networks:
-      - mit-network
     depends_on:
       - redis
 
@@ -62,8 +58,6 @@ services:
       - caddy_config:/config
     depends_on:
       - mitserver
-    networks:
-      - mit-network
 
 volumes:
   caddy_data:
@@ -71,6 +65,6 @@ volumes:
   redis_data:
 
 networks:
-  mit-network:
+  default:
     external: true
     name: ${NETWORK_NAME:-mit-network}


### PR DESCRIPTION
This pull request updates `docker-compose` configuration files by:

- Adding default values for `AUTH_SALT` and `DOMAIN_NAME` to ensure functionality when environment variables are not provided.
- Linking the service to the external `mit-network` and configuring it under networks to support deployment more effectively.