### PR TITLE
Update Dockerfile to use alpine and include CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3 AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG MIT_SERVER=${MIT_SERVER}
 
@@ -12,6 +12,7 @@ RUN CGO_ENABLED=0 go build -o mit -ldflags "-X main.defaultServer=$MIT_SERVER" .
 FROM scratch
 
 COPY --from=builder /app/mit .
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 8080 8081 8082
 


### PR DESCRIPTION
Updated the Dockerfile to utilize `golang:1.24-alpine` as the base image for reduced image size. Added CA certificates to ensure compatibility with SSL/TLS requirements. These changes optimize the image size and enhance functionality.