### PR TITLE
Add Metrics middleware for HTTP request logging

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -36,9 +36,9 @@ type AuthRepo interface {
 }
 
 const (
-	HealthCheckEndpoint   string = "GET /health"
-	GenerateTokenEndpoint string = "POST /generateToken"
-	SwaggerEndpoint       string = "/swagger/"
+	HealthCheckEndpoint   = "GET /health"
+	GenerateTokenEndpoint = "POST /generateToken"
+	SwaggerEndpoint       = "/swagger/"
 )
 
 func New(cfg Config, auth AuthRepo) *API {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 
 	_ "github.com/ksysoev/make-it-public/pkg/api/docs" // needed for swagger
+	"github.com/ksysoev/make-it-public/pkg/api/middleware"
 	"github.com/ksysoev/make-it-public/pkg/core/token"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
@@ -34,12 +35,10 @@ type AuthRepo interface {
 	GenerateToken(ctx context.Context, keyID string, ttl time.Duration) (*token.Token, error)
 }
 
-type Endpoint string
-
 const (
-	HealthCheckEndpoint   Endpoint = "GET /health"
-	GenerateTokenEndpoint Endpoint = "POST /generateToken"
-	SwaggerEndpoint       Endpoint = "/swagger/"
+	HealthCheckEndpoint   string = "GET /health"
+	GenerateTokenEndpoint string = "POST /generateToken"
+	SwaggerEndpoint       string = "/swagger/"
 )
 
 func New(cfg Config, auth AuthRepo) *API {
@@ -58,10 +57,11 @@ func New(cfg Config, auth AuthRepo) *API {
 // Runs the API management server
 func (api *API) Run(ctx context.Context) error {
 	router := http.NewServeMux()
+	genToken := middleware.Metrics()(http.HandlerFunc(api.generateTokenHandler))
 
-	router.HandleFunc((string(HealthCheckEndpoint)), api.healthCheckHandler)
-	router.HandleFunc((string(GenerateTokenEndpoint)), api.generateTokenHandler)
-	router.HandleFunc((string(SwaggerEndpoint)), httpSwagger.WrapHandler)
+	router.Handle(GenerateTokenEndpoint, genToken)
+	router.HandleFunc(HealthCheckEndpoint, api.healthCheckHandler)
+	router.HandleFunc(SwaggerEndpoint, httpSwagger.WrapHandler)
 
 	server := &http.Server{
 		Addr:              api.config.Listen,

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -27,6 +27,7 @@ func Metrics() func(next http.Handler) http.Handler {
 
 			rw := &respWriter{
 				ResponseWriter: w,
+				status:         http.StatusOK, // Initialize with a default status.
 			}
 
 			next.ServeHTTP(rw, r)

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -7,8 +7,8 @@ import (
 )
 
 type respWriter struct {
-	status int
 	http.ResponseWriter
+	status int
 }
 
 // WriteHeader sets the HTTP status code for the response and writes it to the underlying ResponseWriter.
@@ -29,9 +29,8 @@ func Metrics() func(next http.Handler) http.Handler {
 				ResponseWriter: w,
 			}
 
-			defer slog.InfoContext(r.Context(), "mng api request", slog.Duration("duration", time.Since(now)), slog.Int("status", rw.status), slog.String("path", r.URL.Path))
-
 			next.ServeHTTP(rw, r)
+			slog.InfoContext(r.Context(), "mng api request", slog.Duration("duration", time.Since(now)), slog.Int("status", rw.status), slog.String("path", r.URL.Path))
 		})
 	}
 }

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type respWriter struct {
+	status int
+	http.ResponseWriter
+}
+
+// WriteHeader sets the HTTP status code for the response and writes it to the underlying ResponseWriter.
+func (rw *respWriter) WriteHeader(status int) {
+	rw.status = status
+	rw.ResponseWriter.WriteHeader(status)
+}
+
+// Metrics wraps an HTTP handler to log request details such as duration, status code, and path.
+// It returns a middleware handler function that records metrics for incoming requests.
+// Returns an HTTP handler middleware for logging request metrics.
+func Metrics() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			now := time.Now()
+
+			rw := &respWriter{
+				ResponseWriter: w,
+			}
+
+			defer slog.InfoContext(r.Context(), "mng api request", slog.Duration("duration", time.Since(now)), slog.Int("status", rw.status), slog.String("path", r.URL.Path))
+
+			next.ServeHTTP(rw, r)
+		})
+	}
+}

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -95,7 +95,7 @@ func (s *Service) HandleReverseConn(ctx context.Context, revConn net.Conn) error
 
 		defer s.connmng.RemoveConnection(connKeyID, srvConn.ID())
 
-		slog.DebugContext(ctx, "control connection established", slog.Any("remote", revConn.RemoteAddr()))
+		slog.InfoContext(ctx, "control conn established", slog.String("keyID", connKeyID))
 
 		for {
 			select {
@@ -114,7 +114,7 @@ func (s *Service) HandleReverseConn(ctx context.Context, revConn net.Conn) error
 		notifier := conn.NewCloseNotifier(revConn)
 
 		s.connmng.ResolveRequest(servConn.ID(), notifier)
-		slog.DebugContext(ctx, "bound connection established", slog.Any("remote", revConn.RemoteAddr()), slog.Any("id", servConn.ID()))
+		slog.InfoContext(ctx, "rev conn established", slog.String("keyID", connKeyID))
 
 		notifier.WaitClose(ctx)
 

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -60,6 +60,7 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	mw = append(mw,
 		middleware.NewFishingProtection(),
 		middleware.ParseKeyID(s.config.Public.Domain),
+		middleware.Metrics(),
 		middleware.LimitConnections(cmp.Or(s.config.ConnLimit, defaultConnLimitPerKeyID)),
 		middleware.ClientIP(),
 	)

--- a/pkg/edge/middleware/metrics.go
+++ b/pkg/edge/middleware/metrics.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+func Metrics() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			keyID := GetKeyID(r)
+			slog.InfoContext(r.Context(), "connection to edge server", slog.String("key_id", keyID))
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/edge/middleware/metrics.go
+++ b/pkg/edge/middleware/metrics.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 )
 
+// Metrics is an HTTP middleware that logs the "key_id" field from the request context
+// and passes the request to the next handler. It is intended for use in edge server
+// applications to track connections and associated keys.
 func Metrics() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Description
This pull request introduces a `Metrics` middleware to log request metrics such as duration, status, and path for HTTP requests. 

- Added middleware for logging request details, including `key ID` for edge server HTTP requests.
- Integrated the middleware into the token generation endpoint and edge server pipeline.
- Minor refactoring: replaced a custom `Endpoint` type with `string` constants.

### Main Changes
- Request metrics logging using the new `Metrics` middleware.
- Improved observability for edge server and token generation endpoints.