### PR TITLE
Update port bindings for host network mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,19 @@ services:
     cap_add:
       - NET_ADMIN
     ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"
+      # listen on host ports without ingress network
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: udp
+        mode: host
     environment:
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - EMAIL=${EMAIL}


### PR DESCRIPTION
Modified port definitions in `docker-compose` to explicitly use host network mode. This change ensures improved control over service port listening and aligns with specific network configurations while mitigating routing issues in the ingress network.