### PR TITLE
Update Caddyfile to simplify site address configuration

### DIFF
--- a/runtime/Caddyfile
+++ b/runtime/Caddyfile
@@ -12,7 +12,7 @@
 	file_server
 }
 
-http://*.{$DOMAIN_NAME} {
+*.{$DOMAIN_NAME} {
     reverse_proxy http://mitserver:8080 {
         transport http {
             proxy_protocol v2


### PR DESCRIPTION
Simplified the site address in the Caddyfile by removing the explicit `http://` scheme from the site block. This allows Caddy to automatically handle both HTTP and HTTPS requests, improving configuration flexibility and reducing redundancy.