### PR TITLE
Revoke API Tokens via Key ID

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -172,7 +172,7 @@ func (api *API) generateTokenHandler(w http.ResponseWriter, r *http.Request) {
 // @Summary Revoke Token
 // @Description Revokes an API token using the provided Key ID.
 // @Tags Token
-// @Param keyID path int true "Group ID"
+// @Param keyID path string true "API Key ID"
 // @Success 204
 // @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -165,10 +165,9 @@ func (api *API) generateTokenHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// RevokeTokenHandler revokes an API token by deleting it using the provided Key ID.
-// It decodes the incoming JSON request to extract the Key ID and validates it.
-// If the Key ID is missing or invalid, it responds with a 400 Bad Request error.
-// Returns 204 No Content on successful revocation or 500 Internal Server Error on failure.
+// RevokeTokenHandler revokes an API token based on the provided key ID in the request path.
+// It checks the presence of the key ID and returns an HTTP error if missing.
+// Deletes the token and returns a no-content response on success or an internal server error if deletion fails.
 // @Summary Revoke Token
 // @Description Revokes an API token using the provided Key ID.
 // @Tags Token

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -39,7 +39,7 @@ type AuthRepo interface {
 const (
 	HealthCheckEndpoint   = "GET /health"
 	GenerateTokenEndpoint = "POST /generateToken"
-	RevokeTokenEndpoint   = "DELETE /token/{keyID}"
+	RevokeTokenEndpoint   = "DELETE /token/{keyID}" //nolint:gosec // false positive, no hardcoded credentials
 	SwaggerEndpoint       = "/swagger/"
 )
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -38,7 +38,7 @@ type AuthRepo interface {
 
 const (
 	HealthCheckEndpoint   = "GET /health"
-	GenerateTokenEndpoint = "POST /generateToken"
+	GenerateTokenEndpoint = "POST /token"
 	RevokeTokenEndpoint   = "DELETE /token/{keyID}" //nolint:gosec // false positive, no hardcoded credentials
 	SwaggerEndpoint       = "/swagger/"
 )
@@ -124,7 +124,7 @@ func (api *API) healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} GenerateTokenResponse
 // @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"
-// @Router /generateToken [post]
+// @Router /token [post]
 func (api *API) generateTokenHandler(w http.ResponseWriter, r *http.Request) {
 	var generateTokenRequest GenerateTokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&generateTokenRequest); err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -187,6 +187,7 @@ func (api *API) RevokeTokenHandler(w http.ResponseWriter, r *http.Request) {
 	if err := api.auth.DeleteToken(r.Context(), keyID); err != nil {
 		slog.ErrorContext(r.Context(), "Failed to revoke token", "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
 		return
 	}
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -204,7 +204,7 @@ func TestRevokeTokenHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.mockBehavior()
 
-			req := httptest.NewRequest(http.MethodDelete, "/token/"+tt.keyID, nil)
+			req := httptest.NewRequest(http.MethodDelete, "/token/"+tt.keyID, http.NoBody)
 
 			if tt.keyID != "" {
 				req.SetPathValue("keyID", tt.keyID)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -58,7 +58,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 	}, auth)
 
 	t.Run("Invalid Request Payload", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/generateToken", bytes.NewBuffer([]byte("invalid json")))
+		req := httptest.NewRequest(http.MethodPost, "/token", bytes.NewBuffer([]byte("invalid json")))
 		rec := httptest.NewRecorder()
 
 		api.generateTokenHandler(rec, req)
@@ -77,7 +77,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 			TTL: 3600,
 		}
 		body, _ := json.Marshal(requestBody)
-		req := httptest.NewRequest(http.MethodPost, "/generateToken", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/token", bytes.NewBuffer(body))
 		rec := httptest.NewRecorder()
 
 		api.generateTokenHandler(rec, req)
@@ -103,7 +103,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 			TTL:   0,
 		}
 		body, _ := json.Marshal(requestBody)
-		req := httptest.NewRequest(http.MethodPost, "/generateToken", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/token", bytes.NewBuffer(body))
 		rec := httptest.NewRecorder()
 
 		api.generateTokenHandler(rec, req)
@@ -126,7 +126,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 			TTL:   3600,
 		}
 		body, _ := json.Marshal(requestBody)
-		req := httptest.NewRequest(http.MethodPost, "/generateToken", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/token", bytes.NewBuffer(body))
 		rec := httptest.NewRecorder()
 
 		api.generateTokenHandler(rec, req)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -167,11 +167,11 @@ func TestRevokeTokenHandler(t *testing.T) {
 	api := New(Config{}, auth)
 
 	tests := []struct {
+		mockBehavior func()
 		name         string
 		keyID        string
-		mockBehavior func()
-		expectedCode int
 		expectedBody string
+		expectedCode int
 	}{
 		{
 			name:         "Missing KeyID",
@@ -204,7 +204,7 @@ func TestRevokeTokenHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.mockBehavior()
 
-			req := httptest.NewRequest(http.MethodDelete, "/revoke/"+tt.keyID, nil)
+			req := httptest.NewRequest(http.MethodDelete, "/token/"+tt.keyID, nil)
 
 			if tt.keyID != "" {
 				req.SetPathValue("keyID", tt.keyID)

--- a/pkg/api/auth_repo_mock.go
+++ b/pkg/api/auth_repo_mock.go
@@ -26,6 +26,53 @@ func (_m *MockAuthRepo) EXPECT() *MockAuthRepo_Expecter {
 	return &MockAuthRepo_Expecter{mock: &_m.Mock}
 }
 
+// DeleteToken provides a mock function with given fields: ctx, tokenID
+func (_m *MockAuthRepo) DeleteToken(ctx context.Context, tokenID string) error {
+	ret := _m.Called(ctx, tokenID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteToken")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, tokenID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockAuthRepo_DeleteToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteToken'
+type MockAuthRepo_DeleteToken_Call struct {
+	*mock.Call
+}
+
+// DeleteToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tokenID string
+func (_e *MockAuthRepo_Expecter) DeleteToken(ctx interface{}, tokenID interface{}) *MockAuthRepo_DeleteToken_Call {
+	return &MockAuthRepo_DeleteToken_Call{Call: _e.mock.On("DeleteToken", ctx, tokenID)}
+}
+
+func (_c *MockAuthRepo_DeleteToken_Call) Run(run func(ctx context.Context, tokenID string)) *MockAuthRepo_DeleteToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockAuthRepo_DeleteToken_Call) Return(_a0 error) *MockAuthRepo_DeleteToken_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockAuthRepo_DeleteToken_Call) RunAndReturn(run func(context.Context, string) error) *MockAuthRepo_DeleteToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GenerateToken provides a mock function with given fields: ctx, keyID, ttl
 func (_m *MockAuthRepo) GenerateToken(ctx context.Context, keyID string, ttl time.Duration) (*token.Token, error) {
 	ret := _m.Called(ctx, keyID, ttl)

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -102,8 +102,8 @@ const docTemplate = `{
                 "summary": "Revoke Token",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "Group ID",
+                        "type": "string",
+                        "description": "API Key ID",
                         "name": "keyID",
                         "in": "path",
                         "required": true

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -92,6 +92,41 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/token/{keyID}": {
+            "delete": {
+                "description": "Revokes an API token using the provided Key ID.",
+                "tags": [
+                    "Token"
+                ],
+                "summary": "Revoke Token",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Group ID",
+                        "name": "keyID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -15,7 +15,39 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/generateToken": {
+        "/health": {
+            "get": {
+                "description": "Returns the health status of the API.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Health Check",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/token": {
             "post": {
                 "description": "Generates an API token with an optional key ID and TTL.",
                 "consumes": [
@@ -50,38 +82,6 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/health": {
-            "get": {
-                "description": "Returns the health status of the API.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Health"
-                ],
-                "summary": "Health Check",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
                         }
                     },
                     "500": {

--- a/pkg/repo/auth/auth.go
+++ b/pkg/repo/auth/auth.go
@@ -29,6 +29,7 @@ type Config struct {
 type Redis interface {
 	Get(ctx context.Context, key string) *redis.StringCmd
 	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.BoolCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
 	Close() error
 }
 
@@ -106,6 +107,18 @@ func (r *Repo) GenerateToken(ctx context.Context, keyID string, ttl time.Duratio
 	}
 
 	return nil, ErrFailedToGenerateToken
+}
+
+// DeleteToken removes a token identified by tokenID from the database using the configured key prefix.
+// It returns an error if the deletion operation fails.
+func (r *Repo) DeleteToken(ctx context.Context, tokenID string) error {
+	res := r.db.Del(ctx, r.keyPrefix+tokenID)
+
+	if res.Err() != nil {
+		return fmt.Errorf("failed to delete token: %w", res.Err())
+	}
+
+	return nil
 }
 
 // Close releases any resources associated with the Redis connection.

--- a/pkg/repo/auth/auth_test.go
+++ b/pkg/repo/auth/auth_test.go
@@ -224,10 +224,10 @@ func TestHashSecret(t *testing.T) {
 
 func TestRepo_DeleteToken(t *testing.T) {
 	tests := []struct {
+		wantErr   error
+		mockSetup func(m redismock.ClientMock)
 		name      string
 		tokenID   string
-		mockSetup func(m redismock.ClientMock)
-		wantErr   error
 	}{
 		{
 			name:    "successfully delete token",


### PR DESCRIPTION
This pull request introduces a new feature to revoke API tokens, along with associated changes to the API endpoints, documentation, and tests. The most important changes include adding a `RevokeTokenHandler` to the API, updating the API endpoints and documentation, and implementing tests for the new functionality.

### New Feature: Token Revocation

* **API Changes**:
  - Added `DeleteToken` method to the `AuthRepo` interface and its implementation in the `Repo` struct to delete tokens from the database. (`pkg/api/api.go` [[1]](diffhunk://#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dR36-R42) `pkg/repo/auth/auth.go` [[2]](diffhunk://#diff-ad76afe1aea82307fc8b2d45caeb9f3c6a90dfd1d8376197e04a98890ba87f21R112-R123)
  - Introduced a new `RevokeTokenHandler` in the API to handle `DELETE /token/{keyID}` requests for revoking tokens. (`pkg/api/api.go` [pkg/api/api.goR167-R195](diffhunk://#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dR167-R195))
  - Updated the router to include the new `RevokeTokenEndpoint`. (`pkg/api/api.go` [pkg/api/api.goR63-R66](diffhunk://#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dR63-R66))

* **Tests**:
  - Added unit tests for `RevokeTokenHandler` to validate scenarios like successful revocation, missing `keyID`, and internal errors. (`pkg/api/api_test.go` [pkg/api/api_test.goR164-R221](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72R164-R221))
  - Added unit tests for the `DeleteToken` method in the `Repo` struct to verify token deletion behavior under various conditions. (`pkg/repo/auth/auth_test.go` [pkg/repo/auth/auth_test.goR224-R281](diffhunk://#diff-49819660fd1e0305996efdbf8274eadb682cfbad45d8effe604e278f14f65d76R224-R281))

### API Endpoint and Documentation Updates

* **Endpoint Updates**:
  - Renamed the `POST /generateToken` endpoint to `POST /token` for consistency. (`pkg/api/api.go` [pkg/api/api.goL125-R127](diffhunk://#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dL125-R127))
  - Added the new `DELETE /token/{keyID}` endpoint for token revocation. (`pkg/api/api.go` [pkg/api/api.goR36-R42](diffhunk://#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dR36-R42))

* **Documentation**:
  - Updated Swagger documentation to reflect the new endpoints and their descriptions. (`pkg/api/docs/docs.go` [[1]](diffhunk://#diff-53af7853d87d72d2bc11517cd02689ecd4ce8868fd2752cd7d2fe89cbfce01feL18-R50) [[2]](diffhunk://#diff-53af7853d87d72d2bc11517cd02689ecd4ce8868fd2752cd7d2fe89cbfce01feL64-L85)

### Mock and Test Enhancements

* Added a `DeleteToken` mock function to the `MockAuthRepo` for testing purposes. (`pkg/api/auth_repo_mock.go` [pkg/api/auth_repo_mock.goR29-R75](diffhunk://#diff-90be05c18e762f6b933cbad730563cf12a06a92af4645b1feff7ec10107a0f46R29-R75))
* Updated existing tests for the renamed `POST /token` endpoint. (`pkg/api/api_test.go` [[1]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72L61-R61) [[2]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72L80-R80) [[3]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72L106-R106) [[4]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72L129-R129)

These changes ensure that the API supports token revocation while maintaining comprehensive test coverage and updated documentation.
