### PR TITLE
Simplify error response handling in HTTP server

### DIFF
--- a/pkg/core/auth_repo_mock.go
+++ b/pkg/core/auth_repo_mock.go
@@ -71,6 +71,63 @@ func (_c *MockAuthRepo_DeleteToken_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// IsKeyExists provides a mock function with given fields: ctx, keyID
+func (_m *MockAuthRepo) IsKeyExists(ctx context.Context, keyID string) (bool, error) {
+	ret := _m.Called(ctx, keyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsKeyExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, keyID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, keyID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, keyID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockAuthRepo_IsKeyExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsKeyExists'
+type MockAuthRepo_IsKeyExists_Call struct {
+	*mock.Call
+}
+
+// IsKeyExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - keyID string
+func (_e *MockAuthRepo_Expecter) IsKeyExists(ctx interface{}, keyID interface{}) *MockAuthRepo_IsKeyExists_Call {
+	return &MockAuthRepo_IsKeyExists_Call{Call: _e.mock.On("IsKeyExists", ctx, keyID)}
+}
+
+func (_c *MockAuthRepo_IsKeyExists_Call) Run(run func(ctx context.Context, keyID string)) *MockAuthRepo_IsKeyExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockAuthRepo_IsKeyExists_Call) Return(_a0 bool, _a1 error) *MockAuthRepo_IsKeyExists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockAuthRepo_IsKeyExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *MockAuthRepo_IsKeyExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SaveToken provides a mock function with given fields: ctx, t
 func (_m *MockAuthRepo) SaveToken(ctx context.Context, t *token.Token) error {
 	ret := _m.Called(ctx, t)

--- a/pkg/core/conn.go
+++ b/pkg/core/conn.go
@@ -104,8 +104,10 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, keyID string, cliCon
 		}
 
 		if !ok {
-			return ErrKeyIDNotFound
+			return fmt.Errorf("keyID %s not found: %w", keyID, ErrKeyIDNotFound)
 		}
+
+		return fmt.Errorf("no connections available for keyID %s: %w", keyID, ErrFailedToConnect)
 	case err != nil:
 		return fmt.Errorf("failed to request connection: %w", ErrFailedToConnect)
 	}

--- a/pkg/core/conn.go
+++ b/pkg/core/conn.go
@@ -97,7 +97,7 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, keyID string, cliCon
 	req, err := s.connmng.RequestConnection(ctx, keyID)
 
 	switch {
-	case err != nil && errors.Is(err, ErrKeyIDNotFound):
+	case errors.Is(err, ErrKeyIDNotFound):
 		ok, err := s.auth.IsKeyExists(ctx, keyID)
 		if err != nil {
 			return fmt.Errorf("failed to check key existence: %w", err)

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -21,6 +21,7 @@ type AuthRepo interface {
 	Verify(ctx context.Context, keyID, secret string) (bool, error)
 	SaveToken(ctx context.Context, t *token.Token) error
 	DeleteToken(ctx context.Context, tokenID string) error
+	IsKeyExists(ctx context.Context, keyID string) (bool, error)
 }
 
 type ConnManager interface {

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -136,39 +136,37 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case errors.Is(err, core.ErrFailedToConnect):
-		resp := http.Response{
-			Status:        "502 Bad Gateway",
-			StatusCode:    http.StatusBadGateway,
-			Proto:         r.Proto,
-			ProtoMajor:    r.ProtoMajor,
-			ProtoMinor:    r.ProtoMinor,
-			ContentLength: int64(len(htmlErrorTemplate502)),
-			Header:        http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
-			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate502)),
-		}
-
-		if err := resp.Write(clientConn); err != nil {
-			slog.ErrorContext(ctx, "failed to write response", slog.Any("error", err))
-		}
+		sendResponse(r, clientConn, http.StatusBadGateway, htmlErrorTemplate502)
 	case errors.Is(err, core.ErrKeyIDNotFound):
-		resp := http.Response{
-			Status:        "404 Not Found",
-			StatusCode:    http.StatusNotFound,
-			Proto:         r.Proto,
-			ProtoMajor:    r.ProtoMajor,
-			ProtoMinor:    r.ProtoMinor,
-			Header:        http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
-			ContentLength: int64(len(htmlErrorTemplate404)),
-			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate404)),
-		}
-
-		if err := resp.Write(clientConn); err != nil {
-			slog.ErrorContext(ctx, "failed to write response", slog.Any("error", err))
-		}
+		sendResponse(r, clientConn, http.StatusNotFound, htmlErrorTemplate404)
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		slog.DebugContext(ctx, "connection timed out", slog.String("host", r.Host))
 	case err != nil:
 		slog.ErrorContext(ctx, "failed to handle connection", slog.Any("error", err))
 		http.Error(w, "Failed to handle connection: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// sendResponse constructs and sends an HTTP response over a hijacked connection.
+// It builds the response using the provided request protocol details, status code, and body content.
+// r is the original HTTP request from which protocol details are extracted.
+// conn is the hijacked network connection used to write the response.
+// status specifies the HTTP status code for the response.
+// body contains the response body content as a string.
+// Returns nothing but logs an error if writing the response fails.
+func sendResponse(r *http.Request, conn net.Conn, status int, body string) {
+	resp := http.Response{
+		StatusCode:    status,
+		Proto:         r.Proto,
+		ProtoMajor:    r.ProtoMajor,
+		ProtoMinor:    r.ProtoMinor,
+		ContentLength: int64(len(body)),
+		Header:        http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+	}
+
+	if err := resp.Write(conn); err != nil {
+		slog.ErrorContext(r.Context(), "failed to write response", slog.Any("error", err))
+		return
 	}
 }

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -139,6 +139,9 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resp := http.Response{
 			Status:        "502 Bad Gateway",
 			StatusCode:    http.StatusBadGateway,
+			Proto:         r.Proto,
+			ProtoMajor:    r.ProtoMajor,
+			ProtoMinor:    r.ProtoMinor,
 			ContentLength: int64(len(htmlErrorTemplate502)),
 			Header:        http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
 			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate502)),
@@ -151,6 +154,9 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resp := http.Response{
 			Status:        "404 Not Found",
 			StatusCode:    http.StatusNotFound,
+			Proto:         r.Proto,
+			ProtoMajor:    r.ProtoMajor,
+			ProtoMinor:    r.ProtoMinor,
 			Header:        http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
 			ContentLength: int64(len(htmlErrorTemplate404)),
 			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate404)),

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -144,7 +144,7 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate502)),
 		}
 
-		if err := resp.Write(w); err != nil {
+		if err := resp.Write(clientConn); err != nil {
 			slog.ErrorContext(ctx, "failed to write response", slog.Any("error", err))
 		}
 	case errors.Is(err, core.ErrKeyIDNotFound):
@@ -156,7 +156,7 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Body:          io.NopCloser(strings.NewReader(htmlErrorTemplate404)),
 		}
 
-		if err := resp.Write(w); err != nil {
+		if err := resp.Write(clientConn); err != nil {
 			slog.ErrorContext(ctx, "failed to write response", slog.Any("error", err))
 		}
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -43,6 +43,11 @@ type PublicEndpointConfig struct {
 	Port   int    `mapstructure:"port"`
 }
 
+// New initializes and returns an instance of HTTPServer configured with the provided settings and connection service.
+// It validates the configuration by creating a URL endpoint generator and applies it to the connection service.
+// Accepts cfg, a configuration struct defining server and public endpoint parameters, and connService,
+// an interface to manage HTTP connections.
+// Returns a pointer to an HTTPServer if successful or an error if the configuration or endpoint generator fails.
 func New(cfg Config, connService ConnService) (*HTTPServer, error) {
 	generator, err := url.NewEndpointGenerator(cfg.Public.Schema, cfg.Public.Domain, cfg.Public.Port)
 	if err != nil {
@@ -57,6 +62,10 @@ func New(cfg Config, connService ConnService) (*HTTPServer, error) {
 	}, nil
 }
 
+// Run starts the HTTP server and manages its lifecycle using the provided context.
+// It composes middleware, sets up a TCP listener, and creates an HTTP server instance.
+// Accepts ctx to control the server's lifecycle and handle graceful shutdowns.
+// Returns an error if the server fails to start, listen, or encounters unexpected termination issues.
 func (s *HTTPServer) Run(ctx context.Context) error {
 	var mw []func(next http.Handler) http.Handler
 
@@ -105,6 +114,9 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	return nil
 }
 
+// ServeHTTP handles incoming HTTP requests by processing the request context and managing hijacked connections.
+// It uses a hijacker to take control of the underlying connection for advanced protocol handling.
+// Returns appropriate HTTP error responses for unsupported hijacking, connection issues, or context errors.
 func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//nolint:staticcheck,revive // don't want to couple with cmd package for now
 	ctx := context.WithValue(r.Context(), "req_id", uuid.New().String())

--- a/pkg/edge/httpserver_test.go
+++ b/pkg/edge/httpserver_test.go
@@ -1,0 +1,344 @@
+package edge
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ksysoev/make-it-public/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Config
+		expectError bool
+	}{
+		{
+			name: "valid configuration",
+			config: Config{
+				Listen: ":8080",
+				Public: PublicEndpointConfig{
+					Schema: "http",
+					Domain: "example.com",
+					Port:   80,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty schema",
+			config: Config{
+				Listen: ":8080",
+				Public: PublicEndpointConfig{
+					Schema: "",
+					Domain: "example.com",
+					Port:   80,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty domain",
+			config: Config{
+				Listen: ":8080",
+				Public: PublicEndpointConfig{
+					Schema: "http",
+					Domain: "",
+					Port:   80,
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConnService := NewMockConnService(t)
+
+			// Set up expectations for the mock only for the success case
+			// In error cases, SetEndpointGenerator won't be called
+			if !tt.expectError {
+				mockConnService.On("SetEndpointGenerator", mock.AnythingOfType("func(string) (string, error)")).Return()
+			}
+
+			server, err := New(tt.config, mockConnService)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, server)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, server)
+				assert.Equal(t, tt.config, server.config)
+				assert.Equal(t, mockConnService, server.connService)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	// Create a context that we can cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a mock ConnService
+	mockConnService := NewMockConnService(t)
+	mockConnService.On("SetEndpointGenerator", mock.AnythingOfType("func(string) (string, error)")).Return()
+
+	// Create a server with a random port
+	config := Config{
+		Listen: "127.0.0.1:0", // Use port 0 to get a random available port
+		Public: PublicEndpointConfig{
+			Schema: "http",
+			Domain: "example.com",
+			Port:   80,
+		},
+		ConnLimit: 10,
+	}
+
+	server, err := New(config, mockConnService)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	// Start the server in a goroutine
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Run(ctx)
+	}()
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel the context to stop the server
+	cancel()
+
+	// Check if the server stopped without error
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server did not stop within timeout")
+	}
+}
+
+func TestServeHTTP(t *testing.T) {
+	tests := []struct {
+		name           string
+		keyID          string
+		clientIP       string
+		handleConnErr  error
+		expectedStatus int
+	}{
+		{
+			name:           "successful connection",
+			keyID:          "test-key",
+			clientIP:       "192.168.1.1",
+			handleConnErr:  nil,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "failed to connect",
+			keyID:          "test-key",
+			clientIP:       "192.168.1.1",
+			handleConnErr:  core.ErrFailedToConnect,
+			expectedStatus: http.StatusBadGateway,
+		},
+		{
+			name:           "keyID not found",
+			keyID:          "nonexistent-key",
+			clientIP:       "192.168.1.1",
+			handleConnErr:  core.ErrKeyIDNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "context canceled",
+			keyID:          "test-key",
+			clientIP:       "192.168.1.1",
+			handleConnErr:  context.Canceled,
+			expectedStatus: http.StatusOK, // No response is sent for context.Canceled
+		},
+		{
+			name:           "other error",
+			keyID:          "test-key",
+			clientIP:       "192.168.1.1",
+			handleConnErr:  errors.New("some other error"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock ConnService
+			mockConnService := NewMockConnService(t)
+
+			// Create a server
+			config := Config{
+				Listen: ":8080",
+				Public: PublicEndpointConfig{
+					Schema: "http",
+					Domain: "example.com",
+					Port:   80,
+				},
+			}
+
+			// Set up the mock to return the specified error
+			mockConnService.On("SetEndpointGenerator", mock.AnythingOfType("func(string) (string, error)")).Return()
+
+			// The actual call to HandleHTTPConnection will use a context with a req_id value
+			// and empty keyID and clientIP because we haven't set them in the request context
+			mockConnService.On("HandleHTTPConnection",
+				mock.Anything, // Context with req_id
+				mock.Anything, // keyID will be empty because we haven't set it
+				mock.Anything, // The hijacked connection
+				mock.Anything, // The write function
+				mock.Anything, // clientIP will be empty because we haven't set it
+			).Return(tt.handleConnErr)
+
+			server, err := New(config, mockConnService)
+			require.NoError(t, err)
+
+			// Create a request
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			// Mock the GetKeyID and GetClientIP functions by patching the HTTPServer.ServeHTTP method
+			// We'll use the mock ConnService to verify that the correct keyID and clientIP are passed
+
+			// Use a custom ResponseRecorder that implements http.Hijacker
+			w := newHijackableResponseRecorder()
+
+			// For error cases, we need to check that the mock was called with the expected parameters
+			// The actual response status is set by sendResponse, which we test separately
+
+			// Call ServeHTTP
+			server.ServeHTTP(w, req)
+
+			// Verify that the mock was called
+			mockConnService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSendResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		expectBody bool
+	}{
+		{
+			name:       "404 response",
+			status:     http.StatusNotFound,
+			body:       htmlErrorTemplate404,
+			expectBody: true,
+		},
+		{
+			name:       "502 response",
+			status:     http.StatusBadGateway,
+			body:       htmlErrorTemplate502,
+			expectBody: true,
+		},
+		{
+			name:       "custom response",
+			status:     http.StatusOK,
+			body:       "<html><body>Custom response</body></html>",
+			expectBody: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a request
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			// Create a pipe to capture the response
+			clientReader, serverWriter := net.Pipe()
+
+			// Send the response in a goroutine
+			go func() {
+				sendResponse(req, serverWriter, tt.status, tt.body)
+				_ = serverWriter.Close()
+			}()
+
+			// Read the response
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, clientReader)
+			require.NoError(t, err)
+
+			// Check the response
+			response := buf.String()
+			assert.Contains(t, response, fmt.Sprintf("HTTP/1.1 %d %s", tt.status, http.StatusText(tt.status)))
+
+			if tt.expectBody {
+				assert.Contains(t, response, "Content-Type: text/html; charset=utf-8")
+				assert.Contains(t, response, tt.body)
+			}
+		})
+	}
+}
+
+// Custom ResponseRecorder that implements http.Hijacker
+type hijackableResponseRecorder struct {
+	*httptest.ResponseRecorder
+	closeNotify chan bool
+}
+
+func newHijackableResponseRecorder() *hijackableResponseRecorder {
+	return &hijackableResponseRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		closeNotify:      make(chan bool, 1),
+	}
+}
+
+func (hrw *hijackableResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	// Return a mock connection
+	return hrw, bufio.NewReadWriter(
+		bufio.NewReader(strings.NewReader("")),
+		bufio.NewWriter(hrw.ResponseRecorder.Body),
+	), nil
+}
+
+func (hrw *hijackableResponseRecorder) Close() error {
+	hrw.closeNotify <- true
+	return nil
+}
+
+func (hrw *hijackableResponseRecorder) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (hrw *hijackableResponseRecorder) Write(p []byte) (int, error) {
+	return hrw.ResponseRecorder.Body.Write(p)
+}
+
+func (hrw *hijackableResponseRecorder) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8080}
+}
+
+func (hrw *hijackableResponseRecorder) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 12345}
+}
+
+func (hrw *hijackableResponseRecorder) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (hrw *hijackableResponseRecorder) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (hrw *hijackableResponseRecorder) SetWriteDeadline(_ time.Time) error {
+	return nil
+}

--- a/pkg/edge/httpserver_test.go
+++ b/pkg/edge/httpserver_test.go
@@ -136,10 +136,10 @@ func TestRun(t *testing.T) {
 
 func TestServeHTTP(t *testing.T) {
 	tests := []struct {
+		handleConnErr  error
 		name           string
 		keyID          string
 		clientIP       string
-		handleConnErr  error
 		expectedStatus int
 	}{
 		{
@@ -211,7 +211,7 @@ func TestServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a request
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 
 			// Mock the GetKeyID and GetClientIP functions by patching the HTTPServer.ServeHTTP method
 			// We'll use the mock ConnService to verify that the correct keyID and clientIP are passed
@@ -234,8 +234,8 @@ func TestServeHTTP(t *testing.T) {
 func TestSendResponse(t *testing.T) {
 	tests := []struct {
 		name       string
-		status     int
 		body       string
+		status     int
 		expectBody bool
 	}{
 		{
@@ -261,7 +261,7 @@ func TestSendResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a request
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 
 			// Create a pipe to capture the response
 			clientReader, serverWriter := net.Pipe()
@@ -306,7 +306,7 @@ func (hrw *hijackableResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, er
 	// Return a mock connection
 	return hrw, bufio.NewReadWriter(
 		bufio.NewReader(strings.NewReader("")),
-		bufio.NewWriter(hrw.ResponseRecorder.Body),
+		bufio.NewWriter(hrw.Body),
 	), nil
 }
 
@@ -320,7 +320,7 @@ func (hrw *hijackableResponseRecorder) Read(_ []byte) (int, error) {
 }
 
 func (hrw *hijackableResponseRecorder) Write(p []byte) (int, error) {
-	return hrw.ResponseRecorder.Body.Write(p)
+	return hrw.Body.Write(p)
 }
 
 func (hrw *hijackableResponseRecorder) LocalAddr() net.Addr {

--- a/pkg/edge/static.go
+++ b/pkg/edge/static.go
@@ -1,0 +1,25 @@
+package edge
+
+const htmlErrorTemplate502 = `<!DOCTYPE html>
+<html>
+<head>
+	<title>502 Bad Gateway</title>
+</head>
+<body>
+	<h1>502 Bad Gateway</h1>
+	<p>The server received an invalid response from the upstream server.</p>
+	<p>Please try again later.</p>
+</body>
+</html>`
+
+const htmlErrorTemplate404 = `<!DOCTYPE html>
+<html>
+<head>
+	<title>404 Not Found</title>
+</head>
+<body>
+	<h1>404 Not Found</h1>
+	<p>The requested resource could not be found on this server.</p>
+	<p>Please check the URL and try again.</p>
+</body>
+</html>`

--- a/pkg/repo/connmng/connmng.go
+++ b/pkg/repo/connmng/connmng.go
@@ -74,7 +74,7 @@ func (cm *ConnManager) RequestConnection(ctx context.Context, keyID string) (con
 
 	revConn, ok := cm.conns[keyID]
 	if !ok {
-		return nil, fmt.Errorf("no connections for user %s", keyID)
+		return nil, core.ErrKeyIDNotFound
 	}
 
 	req, err := revConn.RequestConnection()

--- a/pkg/repo/connmng/connmng_test.go
+++ b/pkg/repo/connmng/connmng_test.go
@@ -70,7 +70,7 @@ func TestConnManager_RequestConnection_NoConnection(t *testing.T) {
 	cm := New()
 	_, err := cm.RequestConnection(context.Background(), "key1")
 
-	assert.ErrorContains(t, err, "no connections for user")
+	assert.ErrorIs(t, err, core.ErrKeyIDNotFound)
 }
 
 func TestConnManager_RequestConnection_Error(t *testing.T) {


### PR DESCRIPTION
Refactored HTTP error response handling by replacing manual response construction with the `http.Response` struct. This improves readability, ensures consistent handling of "502 Bad Gateway" responses, and enhances error logging clarity.