### PR TITLE
Add consistent key prefix handling in auth repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,13 @@ services:
     restart: unless-stopped
     container_name: mitserver
     ports:
-      - "8080" # HTTP server
+      - "8080:8080" # HTTP server
       - "8081:8081" # Reverse proxy
       - "8082:8082" # API server
     environment:
       - AUTH_REDIS_ADDR=redis:6379
       - AUTH_SALT=${AUTH_SALT:-someRandomSalt}
+      - AUTH_KEY_PREFIX=MIT::
       - HTTP_PUBLIC_SCHEMA=https
       - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME:-make-it-public.dev}
       - HTTP_LISTEN=:8080

--- a/pkg/repo/auth/auth.go
+++ b/pkg/repo/auth/auth.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	scryptPrefix = "sc:"
+	apiKeyPrefix = "API_KEY::"
 )
 
 type Config struct {
@@ -61,7 +62,7 @@ func (r *Repo) Verify(ctx context.Context, keyID, secret string) (bool, error) {
 		return false, fmt.Errorf("failed to hash secret: %w", err)
 	}
 
-	res := r.db.Get(ctx, r.keyPrefix+keyID)
+	res := r.db.Get(ctx, r.keyPrefix+apiKeyPrefix+keyID)
 
 	switch res.Err() {
 	case nil:
@@ -83,7 +84,7 @@ func (r *Repo) SaveToken(ctx context.Context, t *token.Token) error {
 		return fmt.Errorf("failed to encrypt secret: %w", err)
 	}
 
-	res := r.db.SetNX(ctx, r.keyPrefix+t.ID, secretHash, t.TTL)
+	res := r.db.SetNX(ctx, r.keyPrefix+apiKeyPrefix+t.ID, secretHash, t.TTL)
 
 	if res.Err() != nil {
 		return fmt.Errorf("failed to save token: %w", res.Err())
@@ -99,7 +100,7 @@ func (r *Repo) SaveToken(ctx context.Context, t *token.Token) error {
 // DeleteToken removes a token identified by tokenID from the database using the configured key prefix.
 // It returns an error if the deletion operation fails.
 func (r *Repo) DeleteToken(ctx context.Context, tokenID string) error {
-	res := r.db.Del(ctx, r.keyPrefix+tokenID)
+	res := r.db.Del(ctx, r.keyPrefix+apiKeyPrefix+tokenID)
 
 	if res.Err() != nil {
 		return fmt.Errorf("failed to delete token: %w", res.Err())

--- a/pkg/repo/auth/auth_test.go
+++ b/pkg/repo/auth/auth_test.go
@@ -29,7 +29,7 @@ func TestRepo_Verify(t *testing.T) {
 			mockSetup: func(m redismock.ClientMock) {
 				val, err := hashSecret("secret123", []byte(""))
 				assert.NoError(t, err)
-				m.ExpectGet("prefixkey123").SetVal(val)
+				m.ExpectGet("prefix::API_KEY::key123").SetVal(val)
 			},
 			want:    true,
 			wantErr: nil,
@@ -39,7 +39,7 @@ func TestRepo_Verify(t *testing.T) {
 			keyID:  "key123",
 			secret: "invalidSecret",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectGet("prefixkey123").SetVal("secret123")
+				m.ExpectGet("prefix::API_KEY::key123").SetVal("secret123")
 			},
 			want:    false,
 			wantErr: nil,
@@ -49,7 +49,7 @@ func TestRepo_Verify(t *testing.T) {
 			keyID:  "key123",
 			secret: "secret123",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectGet("prefixkey123").RedisNil()
+				m.ExpectGet("prefix::API_KEY::key123").RedisNil()
 			},
 			want:    false,
 			wantErr: nil,
@@ -59,7 +59,7 @@ func TestRepo_Verify(t *testing.T) {
 			keyID:  "key123",
 			secret: "secret123",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectGet("prefixkey123").SetErr(assert.AnError)
+				m.ExpectGet("prefix::API_KEY::key123").SetErr(assert.AnError)
 			},
 			want:    false,
 			wantErr: assert.AnError,
@@ -73,7 +73,7 @@ func TestRepo_Verify(t *testing.T) {
 
 			r := &Repo{
 				db:        rdb,
-				keyPrefix: "prefix",
+				keyPrefix: "prefix::",
 			}
 
 			got, err := r.Verify(context.Background(), tt.keyID, tt.secret)
@@ -129,7 +129,7 @@ func TestRepo_SaveToken(t *testing.T) {
 
 			r := &Repo{
 				db:        rdb,
-				keyPrefix: "prefix",
+				keyPrefix: "prefix::",
 				salt:      []byte("test-salt"),
 			}
 
@@ -233,7 +233,7 @@ func TestRepo_DeleteToken(t *testing.T) {
 			name:    "successfully delete token",
 			tokenID: "token123",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectDel("prefixtoken123").SetVal(1)
+				m.ExpectDel("prefix::API_KEY::token123").SetVal(1)
 			},
 			wantErr: nil,
 		},
@@ -241,7 +241,7 @@ func TestRepo_DeleteToken(t *testing.T) {
 			name:    "token does not exist",
 			tokenID: "nonexistentToken",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectDel("prefixnonexistentToken").SetVal(0)
+				m.ExpectDel("prefix::API_KEY::nonexistentToken").SetVal(0)
 			},
 			wantErr: core.ErrTokenNotFound,
 		},
@@ -249,7 +249,7 @@ func TestRepo_DeleteToken(t *testing.T) {
 			name:    "redis error during deletion",
 			tokenID: "tokenWithError",
 			mockSetup: func(m redismock.ClientMock) {
-				m.ExpectDel("prefixtokenWithError").SetErr(assert.AnError)
+				m.ExpectDel("prefix::API_KEY::tokenWithError").SetErr(assert.AnError)
 			},
 			wantErr: assert.AnError,
 		},
@@ -263,7 +263,7 @@ func TestRepo_DeleteToken(t *testing.T) {
 
 			r := &Repo{
 				db:        rdb,
-				keyPrefix: "prefix",
+				keyPrefix: "prefix::",
 			}
 
 			// Act


### PR DESCRIPTION
### Description
Introduced a standardized `API_KEY::` prefix for key management in the auth repository to ensure uniformity in token storage and retrieval. Adjusted the `docker-compose.yml` to include `AUTH_KEY_PREFIX` and updated related tests to align with the changes.

### Changes
- Implemented uniform `API_KEY::` prefix for keys in the auth repository.
- Updated `docker-compose.yml` to include `AUTH_KEY_PREFIX`.
- Revised existing tests to accommodate the new key prefix format.