### PR TITLE
Update AUTH_KEY_PREFIX formatting in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - AUTH_REDIS_ADDR=redis:6379
       - AUTH_SALT=${AUTH_SALT:-someRandomSalt}
-      - AUTH_KEY_PREFIX=MIT::
+      - "AUTH_KEY_PREFIX=MIT::"
       - HTTP_PUBLIC_SCHEMA=https
       - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME:-make-it-public.dev}
       - HTTP_LISTEN=:8080


### PR DESCRIPTION
Improved the `docker-compose.yml` configuration by enclosing the `AUTH_KEY_PREFIX` value in quotes. This ensures the proper handling of the variable by the parser and prevents inconsistencies. No functional changes were introduced.