### PR TITLE
Update default server URL to production endpoint

### DIFF
--- a/cmd/mit/main.go
+++ b/cmd/mit/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ksysoev/make-it-public/pkg/cmd"
 )
 
-var defaultServer = "localhost:8081"
+var defaultServer = "make-it-public.dev:8081"
 var version = "dev"
 
 func main() {


### PR DESCRIPTION
Updated the default server URL from "localhost:8081" to "make-it-public.dev:8081" to ensure the application connects to the proper production server by default. No further changes have been made.