### PR TITLE
Update docker-compose.yml to use MIT_VERSION for image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   mitserver:
     build:
       context: .
-    image: "ghcr.io/ksysoev/make-it-public:${VERSION:-latest}"
+    image: "ghcr.io/ksysoev/make-it-public:${MIT_VERSION:-latest}"
     restart: unless-stopped
     container_name: mitserver
     ports:


### PR DESCRIPTION
This pull request includes a small update to the `docker-compose.yml` file. The change modifies the image version reference for the `mitserver` service to use the `MIT_VERSION` environment variable instead of the generic `VERSION` variable.