### PR TITLE
Update `docker-compose.yml` to use explicit port mapping configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,18 @@ services:
     restart: unless-stopped
     container_name: mitserver
     ports:
-      - "8080:8080" # HTTP server
-      - "8081:8081" # Reverse proxy
-      - "8082:8082" # API server
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
+      - target: 8081
+        published: 8081
+        protocol: tcp
+        mode: host
+      - target: 8082
+        published: 8082
+        protocol: tcp
+        mode: host
     environment:
       - AUTH_REDIS_ADDR=redis:6379
       - AUTH_SALT=${AUTH_SALT:-someRandomSalt}


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to enhance port configuration by switching from a simple port mapping format to a more detailed configuration using Docker's `target`, `published`, `protocol`, and `mode` options.

### Changes to port configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L18-R29): Replaced the old port mapping syntax (e.g., `"8080:8080"`) with a more explicit configuration specifying `target`, `published`, `protocol`, and `mode` for each port. This change provides greater clarity and flexibility in defining how ports are exposed.