### PR TITLE
Use `context.TODO` instead of `context` from `errgroup` in `conn.NewContextConnNopCloser` creation.

### DIFF
--- a/pkg/core/conn.go
+++ b/pkg/core/conn.go
@@ -149,7 +149,7 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, keyID string, cliCon
 	}
 
 	// Create error group for managing both copy operations
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, ctx := errgroup.WithContext(context.TODO())
 	connNopCloser := conn.NewContextConnNopCloser(ctx, cliConn)
 	respBytesWritten := int64(0)
 


### PR DESCRIPTION
For debug based on documentation http should not be cancelled, based on log error group context should not be canceller neither 