### PR TITLE
Debug context cancelation 

### DIFF
--- a/pkg/core/conn.go
+++ b/pkg/core/conn.go
@@ -149,8 +149,7 @@ func (s *Service) HandleHTTPConnection(ctx context.Context, keyID string, cliCon
 		return fmt.Errorf("failed to write initial request: %w", ErrFailedToConnect)
 	}
 
-	// Create error group for managing both copy operations
-	eg, ctx := errgroup.WithContext(context.TODO())
+	eg, ctx := errgroup.WithContext(ctx)
 	connNopCloser := conn.NewContextConnNopCloser(ctx, cliConn)
 	respBytesWritten := int64(0)
 
@@ -235,9 +234,9 @@ func closeOnContextDone(reqCtx, parentCtx context.Context, c conn.WithWriteClose
 
 		select {
 		case <-reqCtx.Done():
-			slog.DebugContext(reqCtx, "closing connection, request context done")
+			slog.DebugContext(reqCtx, "closing connection, request context done", slog.Any("error", reqCtx.Err()))
 		case <-parentCtx.Done():
-			slog.DebugContext(reqCtx, "closing connection, parent context done")
+			slog.DebugContext(reqCtx, "closing connection, parent context done", slog.Any("error", parentCtx.Err()))
 		}
 
 		slog.DebugContext(reqCtx, "closing connection, context done")

--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -91,7 +91,6 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	server := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
-		WriteTimeout:      5 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
This pull request includes updates to improve context handling and debugging in the `pkg/core/conn.go` file, as well as a minor adjustment to the HTTP server configuration in `pkg/edge/httpserver.go`.

### Context handling improvements:

* [`pkg/core/conn.go`](diffhunk://#diff-028e228def8b67a843e5561c7897b77e5494809690c14b8184a0430d4abdbe96L152-R152): Updated `errgroup.WithContext` to use the provided `ctx` instead of creating a new context, ensuring better alignment with the parent context.
* [`pkg/core/conn.go`](diffhunk://#diff-028e228def8b67a843e5561c7897b77e5494809690c14b8184a0430d4abdbe96L238-R239): Enhanced debugging by adding error details to `slog.DebugContext` calls when closing connections due to context completion.

### HTTP server configuration adjustment:

* [`pkg/edge/httpserver.go`](diffhunk://#diff-181dacfea88402803c87e761fcd4175988cf7585538e6b5d4b26a8baff0a729bL94): Removed the `WriteTimeout` configuration from the HTTP server setup, potentially allowing for more flexible handling of write operations.