### PR TITLE
Add `ReqID` middleware for request tracking and integrate it into the HTTP server

### DIFF
--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/ksysoev/make-it-public/pkg/core"
 	"github.com/ksysoev/make-it-public/pkg/core/url"
 	"github.com/ksysoev/make-it-public/pkg/edge/middleware"
@@ -75,6 +74,7 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 		middleware.Metrics(),
 		middleware.LimitConnections(cmp.Or(s.config.ConnLimit, defaultConnLimitPerKeyID)),
 		middleware.ClientIP(),
+		middleware.ReqID(),
 	)
 
 	var handler http.Handler = s
@@ -110,12 +110,9 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 // It uses a hijacker to take control of the underlying connection for advanced protocol handling.
 // Returns appropriate HTTP error responses for unsupported hijacking, connection issues, or context errors.
 func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	//nolint:staticcheck,revive // don't want to couple with cmd package for now
-	ctx := context.WithValue(r.Context(), "req_id", uuid.New().String())
-
 	hj, ok := w.(http.Hijacker)
 	if !ok {
-		slog.ErrorContext(ctx, "webserver doesn't support hijacking", slog.String("host", r.Host))
+		slog.ErrorContext(r.Context(), "webserver doesn't support hijacking", slog.String("host", r.Host))
 		http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
 
 		return
@@ -123,13 +120,15 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	clientConn, _, err := hj.Hijack()
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to hijack connection", slog.Any("error", err))
+		slog.ErrorContext(r.Context(), "failed to hijack connection", slog.Any("error", err))
 		http.Error(w, "Failed to hijack connection: "+err.Error(), http.StatusInternalServerError)
 
 		return
 	}
 
 	defer func() { _ = clientConn.Close() }()
+
+	ctx := r.Context()
 
 	keyID := middleware.GetKeyID(r)
 	clientIP := middleware.GetClientIP(r)

--- a/pkg/edge/middleware/req_id.go
+++ b/pkg/edge/middleware/req_id.go
@@ -13,6 +13,7 @@ import (
 func ReqID() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			//nolint:staticcheck,revive // don't want to couple with cmd package for now
 			ctx := context.WithValue(r.Context(), "req_id", uuid.New().String())
 			r = r.WithContext(ctx)
 

--- a/pkg/edge/middleware/req_id.go
+++ b/pkg/edge/middleware/req_id.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// ReqID adds a unique request ID to the context of each incoming HTTP request for tracking and correlation.
+// It generates a new UUID for every request and stores it in the context under the key "req_id".
+// Returns a middleware function wrapping an http.Handler and an error if middleware logic fails.
+func ReqID() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), "req_id", uuid.New().String())
+			r = r.WithContext(ctx)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/edge/middleware/req_id_test.go
+++ b/pkg/edge/middleware/req_id_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestReqID_BasicRequest(t *testing.T) {
 	var capturedReqID string
+
 	handler := ReqID()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqID := r.Context().Value("req_id")
 		require.NotNil(t, reqID)
@@ -22,12 +23,13 @@ func TestReqID_BasicRequest(t *testing.T) {
 
 		_, err := uuid.Parse(reqIDStr)
 		require.NoError(t, err)
+
 		capturedReqID = reqIDStr
 
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	// Act

--- a/pkg/edge/middleware/req_id_test.go
+++ b/pkg/edge/middleware/req_id_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReqID_BasicRequest(t *testing.T) {
+	var capturedReqID string
+	handler := ReqID()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := r.Context().Value("req_id")
+		require.NotNil(t, reqID)
+
+		reqIDStr, ok := reqID.(string)
+		require.True(t, ok)
+		require.NotEmpty(t, reqIDStr)
+
+		_, err := uuid.Parse(reqIDStr)
+		require.NoError(t, err)
+		capturedReqID = reqIDStr
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(resp, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.NotEmpty(t, capturedReqID)
+}


### PR DESCRIPTION
This pull request introduces a new middleware for generating unique request IDs (`ReqID`) and integrates it into the HTTP server. It also refactors the handling of request contexts to improve maintainability and consistency. The changes include adding the `ReqID` middleware, removing direct UUID generation from the server code, and introducing tests for the new middleware.

### Middleware enhancement:

* Added a new `ReqID` middleware in `pkg/edge/middleware/req_id.go` to generate and attach a unique request ID to the context of each HTTP request. This enables better tracking and correlation of requests.
* Integrated the `ReqID` middleware into the HTTP server by adding it to the middleware chain in the `Run` method of `pkg/edge/httpserver.go`.

### Code refactoring:

* Removed the direct generation of UUIDs in the `ServeHTTP` method of `pkg/edge/httpserver.go` and replaced it with the context-based request ID provided by the `ReqID` middleware.
* Updated logging in `ServeHTTP` to use the request's existing context instead of creating a new one, ensuring consistency and leveraging the middleware-provided context.

### Testing:

* Added unit tests for the `ReqID` middleware in `pkg/edge/middleware/req_id_test.go` to validate that a unique request ID is correctly generated, attached to the context, and retrievable during request handling.