### PR TITLE
Add customizable response handling for dummy server

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -35,7 +35,7 @@ func TestHealthCheckHandler(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code, "Expected status code 200")
-	assert.Equal(t, rr.Body.String(), "healthy", "Response body does not match expected")
+	assert.Equal(t, rr.Body.String(), "healthy", "Body body does not match expected")
 }
 
 func TestHealthCheckHandler_Error(t *testing.T) {
@@ -50,7 +50,7 @@ func TestHealthCheckHandler_Error(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code, "Expected status code 500")
-	assert.Equal(t, rr.Body.String(), "Internal Server Error\n", "Response body does not match expected")
+	assert.Equal(t, rr.Body.String(), "Internal Server Error\n", "Body body does not match expected")
 }
 
 func TestGenerateTokenHandler(t *testing.T) {

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -26,7 +26,24 @@ func RunClientCommand(ctx context.Context, args *args) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	if exposeAddr == "" && args.LocalServer {
-		lclSrv := dummy.New()
+		if args.Status < 200 || args.Status >= 600 {
+			return fmt.Errorf("invalid status code: %d", args.Status)
+		}
+
+		resp := dummy.Response{
+			Status: args.Status,
+		}
+
+		switch {
+		case args.JSONResponse != "":
+			resp.Body = args.JSONResponse
+			resp.ContentType = "application/json"
+		case args.Reponse != "":
+			resp.Body = args.Reponse
+			resp.ContentType = "text/plain"
+		}
+
+		lclSrv := dummy.New(resp)
 
 		eg.Go(func() error { return lclSrv.Run(ctx) })
 

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -35,6 +35,8 @@ func RunClientCommand(ctx context.Context, args *args) error {
 		}
 
 		switch {
+		case args.JSONResponse != "" && args.Response != "":
+			return fmt.Errorf("cannot specify both body and json responses at the same time")
 		case args.JSONResponse != "":
 			resp.Body = args.JSONResponse
 			resp.ContentType = "application/json"

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -38,8 +38,8 @@ func RunClientCommand(ctx context.Context, args *args) error {
 		case args.JSONResponse != "":
 			resp.Body = args.JSONResponse
 			resp.ContentType = "application/json"
-		case args.Reponse != "":
-			resp.Body = args.Reponse
+		case args.Response != "":
+			resp.Body = args.Response
 			resp.ContentType = "text/plain"
 		}
 

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -26,26 +26,15 @@ func RunClientCommand(ctx context.Context, args *args) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	if exposeAddr == "" && args.LocalServer {
-		if args.Status < 200 || args.Status >= 600 {
-			return fmt.Errorf("invalid status code: %d", args.Status)
-		}
-
-		resp := dummy.Response{
+		lclSrv, err := dummy.New(dummy.Config{
 			Status: args.Status,
-		}
+			JSON:   args.JSON,
+			Body:   args.Body,
+		})
 
-		switch {
-		case args.JSONResponse != "" && args.Response != "":
-			return fmt.Errorf("cannot specify both body and json responses at the same time")
-		case args.JSONResponse != "":
-			resp.Body = args.JSONResponse
-			resp.ContentType = "application/json"
-		case args.Response != "":
-			resp.Body = args.Response
-			resp.ContentType = "text/plain"
+		if err != nil {
+			return fmt.Errorf("failed to create local server: %w", err)
 		}
-
-		lclSrv := dummy.New(resp)
 
 		eg.Go(func() error { return lclSrv.Run(ctx) })
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -13,20 +13,20 @@ type BuildInfo struct {
 	Version       string
 }
 type args struct {
-	Server       string `mapstructure:"server"`
+	Response     string `mapstructure:"response"`
 	Expose       string `mapstructure:"expose"`
 	Token        string `mapstructure:"token"`
 	ConfigPath   string `mapstructure:"config"`
 	LogLevel     string `mapstructure:"log_level"`
 	Version      string
-	NoTLS        bool   `mapstructure:"no_tls"`
-	Insecure     bool   `mapstructure:"insecure"`
-	TextFormat   bool   `mapstructure:"log_text"`
-	LocalServer  bool   `mapstructure:"local"`
-	Interactive  bool   `mapstructure:"interactive"`
-	Reponse      string `mapstructure:"response"`
+	Server       string `mapstructure:"server"`
 	JSONResponse string `mapstructure:"json_response"`
 	Status       int    `mapstructure:"status"`
+	NoTLS        bool   `mapstructure:"no_tls"`
+	Interactive  bool   `mapstructure:"interactive"`
+	LocalServer  bool   `mapstructure:"local"`
+	TextFormat   bool   `mapstructure:"log_text"`
+	Insecure     bool   `mapstructure:"insecure"`
 }
 
 // InitCommand initializes the root command of the CLI application with its subcommands and flags.
@@ -54,7 +54,7 @@ func InitCommand(build BuildInfo) cobra.Command {
 	cmd.Flags().BoolVar(&arg.NoTLS, "no-tls", false, "disable TLS")
 	cmd.Flags().BoolVar(&arg.Insecure, "insecure", false, "skip TLS verification")
 	cmd.Flags().BoolVar(&arg.LocalServer, "dummy", false, "run local dummy web server that will print incoming requests(experimental feature)")
-	cmd.Flags().StringVar(&arg.Reponse, "response", "", "response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.Response, "response", "", "response to send back to the client by the dummy server")
 	cmd.Flags().StringVar(&arg.JSONResponse, "json-response", "", "JSON response to send back to the client by the dummy server")
 	cmd.Flags().IntVar(&arg.Status, "status", 200, "HTTP status code to return by the dummy server")
 	cmd.Flags().BoolVar(&arg.Interactive, "interactive", isInteractive, "run in interactive mode")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -54,8 +54,8 @@ func InitCommand(build BuildInfo) cobra.Command {
 	cmd.Flags().BoolVar(&arg.NoTLS, "no-tls", false, "disable TLS")
 	cmd.Flags().BoolVar(&arg.Insecure, "insecure", false, "skip TLS verification")
 	cmd.Flags().BoolVar(&arg.LocalServer, "dummy", false, "run local dummy web server that will print incoming requests(experimental feature)")
-	cmd.Flags().StringVar(&arg.Response, "response", "", "response to send back to the client by the dummy server")
-	cmd.Flags().StringVar(&arg.JSONResponse, "json-response", "", "JSON response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.Response, "body", "", "response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.JSONResponse, "json", "", "JSON response to send back to the client by the dummy server")
 	cmd.Flags().IntVar(&arg.Status, "status", 200, "HTTP status code to return by the dummy server")
 	cmd.Flags().BoolVar(&arg.Interactive, "interactive", isInteractive, "run in interactive mode")
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -13,17 +13,20 @@ type BuildInfo struct {
 	Version       string
 }
 type args struct {
-	Server      string `mapstructure:"server"`
-	Expose      string `mapstructure:"expose"`
-	Token       string `mapstructure:"token"`
-	ConfigPath  string `mapstructure:"config"`
-	LogLevel    string `mapstructure:"log_level"`
-	Version     string
-	NoTLS       bool `mapstructure:"no_tls"`
-	Insecure    bool `mapstructure:"insecure"`
-	TextFormat  bool `mapstructure:"log_text"`
-	LocalServer bool `mapstructure:"local"`
-	Interactive bool `mapstructure:"interactive"`
+	Server       string `mapstructure:"server"`
+	Expose       string `mapstructure:"expose"`
+	Token        string `mapstructure:"token"`
+	ConfigPath   string `mapstructure:"config"`
+	LogLevel     string `mapstructure:"log_level"`
+	Version      string
+	NoTLS        bool   `mapstructure:"no_tls"`
+	Insecure     bool   `mapstructure:"insecure"`
+	TextFormat   bool   `mapstructure:"log_text"`
+	LocalServer  bool   `mapstructure:"local"`
+	Interactive  bool   `mapstructure:"interactive"`
+	Reponse      string `mapstructure:"response"`
+	JSONResponse string `mapstructure:"json_response"`
+	Status       int    `mapstructure:"status"`
 }
 
 // InitCommand initializes the root command of the CLI application with its subcommands and flags.
@@ -51,6 +54,9 @@ func InitCommand(build BuildInfo) cobra.Command {
 	cmd.Flags().BoolVar(&arg.NoTLS, "no-tls", false, "disable TLS")
 	cmd.Flags().BoolVar(&arg.Insecure, "insecure", false, "skip TLS verification")
 	cmd.Flags().BoolVar(&arg.LocalServer, "dummy", false, "run local dummy web server that will print incoming requests(experimental feature)")
+	cmd.Flags().StringVar(&arg.Reponse, "response", "", "response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.JSONResponse, "json-response", "", "JSON response to send back to the client by the dummy server")
+	cmd.Flags().IntVar(&arg.Status, "status", 200, "HTTP status code to return by the dummy server")
 	cmd.Flags().BoolVar(&arg.Interactive, "interactive", isInteractive, "run in interactive mode")
 
 	cmd.PersistentFlags().StringVar(&arg.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -13,20 +13,20 @@ type BuildInfo struct {
 	Version       string
 }
 type args struct {
-	Response     string `mapstructure:"response"`
-	Expose       string `mapstructure:"expose"`
-	Token        string `mapstructure:"token"`
-	ConfigPath   string `mapstructure:"config"`
-	LogLevel     string `mapstructure:"log_level"`
-	Version      string
-	Server       string `mapstructure:"server"`
-	JSONResponse string `mapstructure:"json_response"`
-	Status       int    `mapstructure:"status"`
-	NoTLS        bool   `mapstructure:"no_tls"`
-	Interactive  bool   `mapstructure:"interactive"`
-	LocalServer  bool   `mapstructure:"local"`
-	TextFormat   bool   `mapstructure:"log_text"`
-	Insecure     bool   `mapstructure:"insecure"`
+	Body        string `mapstructure:"body"`
+	Expose      string `mapstructure:"expose"`
+	Token       string `mapstructure:"token"`
+	ConfigPath  string `mapstructure:"config"`
+	LogLevel    string `mapstructure:"log_level"`
+	Version     string
+	Server      string `mapstructure:"server"`
+	JSON        string `mapstructure:"json"`
+	Status      int    `mapstructure:"status"`
+	NoTLS       bool   `mapstructure:"no_tls"`
+	Interactive bool   `mapstructure:"interactive"`
+	LocalServer bool   `mapstructure:"local"`
+	TextFormat  bool   `mapstructure:"log_text"`
+	Insecure    bool   `mapstructure:"insecure"`
 }
 
 // InitCommand initializes the root command of the CLI application with its subcommands and flags.
@@ -54,8 +54,8 @@ func InitCommand(build BuildInfo) cobra.Command {
 	cmd.Flags().BoolVar(&arg.NoTLS, "no-tls", false, "disable TLS")
 	cmd.Flags().BoolVar(&arg.Insecure, "insecure", false, "skip TLS verification")
 	cmd.Flags().BoolVar(&arg.LocalServer, "dummy", false, "run local dummy web server that will print incoming requests(experimental feature)")
-	cmd.Flags().StringVar(&arg.Response, "body", "", "response to send back to the client by the dummy server")
-	cmd.Flags().StringVar(&arg.JSONResponse, "json", "", "JSON response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.Body, "body", "", "response to send back to the client by the dummy server")
+	cmd.Flags().StringVar(&arg.JSON, "json", "", "JSON response to send back to the client by the dummy server")
 	cmd.Flags().IntVar(&arg.Status, "status", 200, "HTTP status code to return by the dummy server")
 	cmd.Flags().BoolVar(&arg.Interactive, "interactive", isInteractive, "run in interactive mode")
 

--- a/pkg/cmd/logger_test.go
+++ b/pkg/cmd/logger_test.go
@@ -61,8 +61,8 @@ func TestCreateReplacer(t *testing.T) {
 		inputAttr   slog.Attr
 		expected    slog.Attr
 		name        string
-		arg         args
 		inputGroup  []string
+		arg         args
 		expectedNil bool
 	}{
 		{

--- a/pkg/dummy/srv.go
+++ b/pkg/dummy/srv.go
@@ -35,9 +35,10 @@ type Server struct {
 	resp    Response
 }
 
-// New creates and initializes a new Server instance.
-// It sets up a custom JSON formatter with specific colors for formatting JSON data during HTTP request handling.
-// Returns a pointer to the newly created Server with an initialized readiness channel and JSON formatter.
+// New creates and initializes a new Server instance configured with the provided settings.
+// It validates the Config parameters and determines the response type (JSON or plain text).
+// Accepts cfg Config containing the response body, JSON string, and HTTP status code.
+// Returns a pointer to the Server instance and an error if the configuration is invalid (e.g., status code out of range, both body and JSON set).
 func New(cfg Config) (*Server, error) {
 	if cfg.Status < 200 || cfg.Status >= 600 {
 		return nil, fmt.Errorf("invalid status code: %d", cfg.Status)

--- a/pkg/dummy/srv.go
+++ b/pkg/dummy/srv.go
@@ -119,11 +119,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(s.resp.Status)
-
 	if s.resp.ContentType != "" {
 		w.Header().Set("Content-Type", s.resp.ContentType)
 	}
+
+	w.WriteHeader(s.resp.Status)
 
 	if _, err := w.Write([]byte(s.resp.Body)); err != nil {
 		fmt.Printf("Error writing response: %v\n", err)

--- a/pkg/dummy/srv.go
+++ b/pkg/dummy/srv.go
@@ -18,8 +18,8 @@ import (
 
 type Config struct {
 	Body   string `mapstructure:"body"`
-	Status int    `mapstructure:"status"`
 	JSON   string `mapstructure:"json"`
+	Status int    `mapstructure:"status"`
 }
 
 type Response struct {

--- a/pkg/dummy/srv.go
+++ b/pkg/dummy/srv.go
@@ -17,9 +17,9 @@ import (
 )
 
 type Response struct {
-	Status      int
 	Body        string
 	ContentType string
+	Status      int
 }
 
 type Server struct {
@@ -120,10 +120,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(s.resp.Status)
+
 	if s.resp.ContentType != "" {
 		w.Header().Set("Content-Type", s.resp.ContentType)
 	}
-	_, _ = w.Write([]byte(s.resp.Body))
+
+	if _, err := w.Write([]byte(s.resp.Body)); err != nil {
+		fmt.Printf("Error writing response: %v\n", err)
+	}
 }
 
 // printBody processes and outputs the given data based on its content type.

--- a/pkg/dummy/srv_test.go
+++ b/pkg/dummy/srv_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	server := New()
+	server := New(Response{Status: 200})
 
 	assert.NotNil(t, server, "Server should not be nil")
 	assert.NotNil(t, server.isReady, "isReady channel should not be nil")
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	server := New()
+	server := New(Response{Status: 200, Body: "ok"})
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -73,7 +73,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestAddr(t *testing.T) {
-	server := New()
+	server := New(Response{Status: 200})
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -130,7 +130,7 @@ func TestServeHTTP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New()
+			server := New(Response{Status: 200, Body: "ok"})
 
 			// Create a request
 			var bodyReader io.Reader
@@ -226,7 +226,7 @@ func TestPrintBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New()
+			server := New(Response{Status: 200})
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout
@@ -285,7 +285,7 @@ func TestPrintText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New()
+			server := New(Response{Status: 200})
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout
@@ -336,7 +336,7 @@ func TestPrintJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New()
+			server := New(Response{Status: 200})
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout

--- a/pkg/dummy/srv_test.go
+++ b/pkg/dummy/srv_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	server := New(Response{Status: 200})
+	server, err := New(Config{Status: 200})
 
+	require.NoError(t, err, "Failed to create server")
 	assert.NotNil(t, server, "Server should not be nil")
 	assert.NotNil(t, server.isReady, "isReady channel should not be nil")
 	assert.NotNil(t, server.jsonFmt, "jsonFmt should not be nil")
@@ -28,7 +29,9 @@ func TestNew(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	server := New(Response{Status: 200, Body: "ok"})
+	server, err := New(Config{Status: 200, Body: "ok"})
+
+	require.NoError(t, err, "Failed to create server")
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -73,7 +76,9 @@ func TestRun(t *testing.T) {
 }
 
 func TestAddr(t *testing.T) {
-	server := New(Response{Status: 200})
+	server, err := New(Config{Status: 200})
+
+	require.NoError(t, err, "Failed to create server")
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -130,7 +135,9 @@ func TestServeHTTP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New(Response{Status: 200, Body: "ok"})
+			server, err := New(Config{Status: 200, Body: "ok"})
+
+			require.NoError(t, err, "Failed to create server")
 
 			// Create a request
 			var bodyReader io.Reader
@@ -226,7 +233,9 @@ func TestPrintBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New(Response{Status: 200})
+			server, err := New(Config{Status: 200})
+
+			require.NoError(t, err, "Failed to create server")
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout
@@ -234,7 +243,7 @@ func TestPrintBody(t *testing.T) {
 			os.Stdout = w
 
 			// Call printBody
-			err := server.printBody(tt.data, tt.contentType)
+			err = server.printBody(tt.data, tt.contentType)
 
 			// Restore stdout
 			require.NoError(t, w.Close())
@@ -285,7 +294,9 @@ func TestPrintText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New(Response{Status: 200})
+			server, err := New(Config{Status: 200})
+
+			require.NoError(t, err, "Failed to create server")
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout
@@ -293,7 +304,7 @@ func TestPrintText(t *testing.T) {
 			os.Stdout = w
 
 			// Call printText
-			err := server.printText(tt.data)
+			err = server.printText(tt.data)
 
 			// Restore stdout
 			require.NoError(t, w.Close())
@@ -336,7 +347,9 @@ func TestPrintJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := New(Response{Status: 200})
+			server, err := New(Config{Status: 200})
+
+			require.NoError(t, err, "Failed to create server")
 
 			// Temporarily redirect stdout to capture output
 			oldStdout := os.Stdout
@@ -344,7 +357,7 @@ func TestPrintJSON(t *testing.T) {
 			os.Stdout = w
 
 			// Call printJSON
-			err := server.printJSON(tt.data)
+			err = server.printJSON(tt.data)
 
 			// Restore stdout
 			require.NoError(t, w.Close())


### PR DESCRIPTION
This pull request introduces enhancements to the dummy server functionality, allowing it to return customizable HTTP responses. The changes include support for specifying HTTP status codes, response bodies, and content types via command-line flags, along with updates to the `dummy.Server` implementation to handle these new features.

### Enhancements to dummy server functionality:

* **Customizable HTTP responses in `dummy.Server`:**
  - Added a new `Response` struct in `pkg/dummy/srv.go` to encapsulate HTTP status, body, and content type. The `dummy.Server` now accepts this `Response` struct during initialization and uses it to generate responses. (`[[1]](diffhunk://#diff-3d157ae7a8d28bffaa9cd0b06af8595e6c234860db28c24725f666703ab2b812R19-R35)`, `[[2]](diffhunk://#diff-3d157ae7a8d28bffaa9cd0b06af8595e6c234860db28c24725f666703ab2b812R47)`)
  - Updated `ServeHTTP` method in `dummy.Server` to use the provided `Response` struct for setting HTTP status, headers, and body. (`[pkg/dummy/srv.goL114-R126](diffhunk://#diff-3d157ae7a8d28bffaa9cd0b06af8595e6c234860db28c24725f666703ab2b812L114-R126)`)

* **Command-line flags for dummy server configuration:**
  - Added new flags `--response`, `--json-response`, and `--status` to allow users to specify the response body (plain text or JSON) and HTTP status code for the dummy server. (`[pkg/cmd/init.goR57-R59](diffhunk://#diff-a53aedd081647bc5a1bc5c1a969ad049f4ff08c9b4c5ba9408ea647488849234R57-R59)`)
  - Updated the `args` struct in `pkg/cmd/init.go` to include fields for these new flags: `Reponse`, `JSONResponse`, and `Status`. (`[pkg/cmd/init.goR27-R29](diffhunk://#diff-a53aedd081647bc5a1bc5c1a969ad049f4ff08c9b4c5ba9408ea647488849234R27-R29)`)

* **Validation for HTTP status codes:**
  - Added validation in `RunClientCommand` to ensure the provided HTTP status code is within a valid range (200–599). If invalid, the command returns an error. (`[pkg/cmd/client.goL29-R46](diffhunk://#diff-8ebc448828da85dc6d49c72b32bce69235c77c513d3c84b51f22090f1f8fac67L29-R46)`)