### PR TITLE
Updates linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - nolintlint
     - prealloc
     - predeclared
-    - revive
     - staticcheck
     - thelper
     - tparallel
@@ -28,7 +27,7 @@ linters:
     - unparam
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -86,6 +86,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 		assert.Equal(t, http.StatusCreated, rec.Code)
 
 		var response GenerateTokenResponse
+
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, response.KeyID)
@@ -113,6 +114,7 @@ func TestGenerateTokenHandler(t *testing.T) {
 		assert.Equal(t, http.StatusCreated, rec.Code)
 
 		var response GenerateTokenResponse
+
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-key-id", response.KeyID)

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -31,7 +31,6 @@ func RunClientCommand(ctx context.Context, args *args) error {
 			JSON:   args.JSON,
 			Body:   args.Body,
 		})
-
 		if err != nil {
 			return fmt.Errorf("failed to create local server: %w", err)
 		}

--- a/pkg/core/conn/meta/sender_test.go
+++ b/pkg/core/conn/meta/sender_test.go
@@ -66,8 +66,8 @@ func TestWriteAndReadData(t *testing.T) {
 
 			// Read data from the buffer
 			var result interface{}
-			err = ReadData(&buf, &result)
 
+			err = ReadData(&buf, &result)
 			if err != nil {
 				t.Fatalf("ReadData failed: %v", err)
 			}
@@ -91,8 +91,8 @@ func TestWriteDataExceedingMaxSize(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := WriteData(&buf, string(largeData))
 
+	err := WriteData(&buf, string(largeData))
 	if err == nil {
 		t.Errorf("Expected error for data exceeding max size, got nil")
 	}

--- a/pkg/core/conn/req_test.go
+++ b/pkg/core/conn/req_test.go
@@ -66,6 +66,7 @@ func TestConnReq_WaitConn(t *testing.T) {
 
 			if tt.sendConn {
 				conn := &net.TCPConn{}
+
 				go func() {
 					time.Sleep(10 * time.Millisecond)
 					connReq.SendConn(ctx, conn)

--- a/pkg/core/token.go
+++ b/pkg/core/token.go
@@ -24,7 +24,6 @@ var (
 func (s *Service) GenerateToken(ctx context.Context, keyID string, ttl int) (*token.Token, error) {
 	for i := 0; i < attemptsToGenerateToken; i++ {
 		t, err := token.GenerateToken(keyID, ttl)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate token: %w", err)
 		}

--- a/pkg/core/token/token.go
+++ b/pkg/core/token/token.go
@@ -64,8 +64,8 @@ func GenerateToken(keyID string, ttl int) (*Token, error) {
 	}
 
 	bufferLen := calculateSecretBuffer(len(keyID))
-	secret, err := generateSecret(bufferLen)
 
+	secret, err := generateSecret(bufferLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token secret: %w", err)
 	}
@@ -131,7 +131,6 @@ func generateID() (string, error) {
 // Returns the generated secret string and an error if random number generation fails.
 func generateSecret(bufferLen int) (string, error) {
 	indices, err := randomIntSlice(len(lowerCase+upperCase+numbers), bufferLen)
-
 	if err != nil {
 		return "", err
 	}
@@ -149,8 +148,8 @@ func generateSecret(bufferLen int) (string, error) {
 // It uses cryptographic randomness as the source and returns an error if random number generation fails.
 func randomIntSlice(maxLen, length int) ([]int, error) {
 	b := make([]byte, length)
-	_, err := rand.Read(b)
 
+	_, err := rand.Read(b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dummy/srv_test.go
+++ b/pkg/dummy/srv_test.go
@@ -85,6 +85,7 @@ func TestRun(t *testing.T) {
 
 	// Start the server in a goroutine
 	errCh := make(chan error, 1)
+
 	go func() {
 		errCh <- server.Run(ctx)
 	}()
@@ -214,11 +215,13 @@ func TestServeHTTP(t *testing.T) {
 
 			// Read captured output
 			var buf bytes.Buffer
+
 			_, _ = io.Copy(&buf, r)
 			output := buf.String()
 
 			// Verify response
 			resp := w.Result()
+
 			defer func() { _ = resp.Body.Close() }()
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -298,6 +301,7 @@ func TestPrintBody(t *testing.T) {
 
 			// Read captured output
 			var buf bytes.Buffer
+
 			_, _ = io.Copy(&buf, r)
 			output := buf.String()
 
@@ -359,6 +363,7 @@ func TestPrintText(t *testing.T) {
 
 			// Read captured output
 			var buf bytes.Buffer
+
 			_, _ = io.Copy(&buf, r)
 			output := buf.String()
 
@@ -412,6 +417,7 @@ func TestPrintJSON(t *testing.T) {
 
 			// Read captured output
 			var buf bytes.Buffer
+
 			_, _ = io.Copy(&buf, r)
 			output := buf.String()
 
@@ -422,6 +428,7 @@ func TestPrintJSON(t *testing.T) {
 
 				// Parse the original JSON to verify it's in the output
 				var originalData interface{}
+
 				err := json.Unmarshal(tt.data, &originalData)
 				require.NoError(t, err)
 

--- a/pkg/edge/httpserver_test.go
+++ b/pkg/edge/httpserver_test.go
@@ -115,6 +115,7 @@ func TestRun(t *testing.T) {
 
 	// Start the server in a goroutine
 	errCh := make(chan error, 1)
+
 	go func() {
 		errCh <- server.Run(ctx)
 	}()
@@ -274,6 +275,7 @@ func TestSendResponse(t *testing.T) {
 
 			// Read the response
 			var buf bytes.Buffer
+
 			_, err := io.Copy(&buf, clientReader)
 			require.NoError(t, err)
 

--- a/pkg/revproxy/revserver.go
+++ b/pkg/revproxy/revserver.go
@@ -148,6 +148,7 @@ func loadTLSCertificate(ctx context.Context, certFile, keyFile string, onUpdate 
 		}
 
 		subscriber := w.Subscribe()
+
 		go func() {
 			defer w.Unsubscribe(subscriber)
 

--- a/pkg/revproxy/revserver_test.go
+++ b/pkg/revproxy/revserver_test.go
@@ -126,6 +126,7 @@ func TestRun(t *testing.T) {
 	defer cancel()
 
 	errCh := make(chan error, 1)
+
 	go func() {
 		errCh <- server.Run(ctx)
 	}()

--- a/pkg/revproxy/watcher/file_watcher.go
+++ b/pkg/revproxy/watcher/file_watcher.go
@@ -44,6 +44,7 @@ func NewFileWatcher(paths ...string) (*FileWatcher, error) {
 	}
 
 	fw.wg.Add(1)
+
 	go fw.run()
 
 	return fw, nil


### PR DESCRIPTION
This pull request primarily introduces minor code quality improvements and test refactoring across several packages, with a notable update to the linter configuration. The changes focus on improving code consistency, updating linting rules, and cleaning up test implementations.

**Linter configuration update:**

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L23-R30): Removed the `revive` linter and replaced the `wsl` linter with `wsl_v5` to update linting rules and improve code quality checks.

**Test code refactoring and consistency improvements:**

* `pkg/dummy/srv_test.go`, `pkg/edge/httpserver_test.go`, `pkg/revproxy/revserver_test.go`, `pkg/core/conn/meta/sender_test.go`, `pkg/core/conn/req_test.go`, `pkg/api/api_test.go`: Added blank lines and minor formatting changes to enhance readability and maintain consistent structure in test cases. [[1]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR88) [[2]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR218-R224) [[3]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR304) [[4]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR366) [[5]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR420) [[6]](diffhunk://#diff-dd192e0d4e6619b353d75d589d646d991902003e240c9e14bc5bfafed235699aR431) [[7]](diffhunk://#diff-b0c52c0ab46510053a42ec15fdc76ca7695d8b514fbae52d23eb5fb2a5be1f0bR118) [[8]](diffhunk://#diff-b0c52c0ab46510053a42ec15fdc76ca7695d8b514fbae52d23eb5fb2a5be1f0bR278) [[9]](diffhunk://#diff-1db757505162d6471369ab0baebde1cbd663c904688d638e5ac91f0a7fb0f68cL69-R70) [[10]](diffhunk://#diff-1db757505162d6471369ab0baebde1cbd663c904688d638e5ac91f0a7fb0f68cL94-R95) [[11]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72R89) [[12]](diffhunk://#diff-445f75dbda6fe7b9191d0b2cb94a621ae7a41eb786d6796540df4c6aa7a38d72R117) [[13]](diffhunk://#diff-3d389586dae2da5d82e8988a875de2138a170e6a30fd84a19e9a7351c7be3368R69) [[14]](diffhunk://#diff-3103da04b5b4bb09cc9b06e3d1ac2ab62a87c65b41b24cd7b65ea5ada492e880R129)

**Minor code cleanup:**

* `pkg/core/token.go`, `pkg/core/token/token.go`, `pkg/cmd/client.go`, `pkg/revproxy/revserver.go`, `pkg/revproxy/watcher/file_watcher.go`: Removed unnecessary blank lines and made slight formatting updates for better code clarity and consistency. [[1]](diffhunk://#diff-53c1735dbbe8836ffc29e5949116f3a6f4961b9927a7ff1ea99bdad5784daf51L27) [[2]](diffhunk://#diff-5a40863c6b1554b3071331c72fea32eb46d8c93f990d7911f0be95e57ccd4056L67-R68) [[3]](diffhunk://#diff-5a40863c6b1554b3071331c72fea32eb46d8c93f990d7911f0be95e57ccd4056L134) [[4]](diffhunk://#diff-5a40863c6b1554b3071331c72fea32eb46d8c93f990d7911f0be95e57ccd4056L152-R152) [[5]](diffhunk://#diff-8ebc448828da85dc6d49c72b32bce69235c77c513d3c84b51f22090f1f8fac67L34) [[6]](diffhunk://#diff-b7339d8d3df5cea2144e9f2d2b3f78d98d0e3ce2b5bdef4d0c6e233717c8ab6bR151) [[7]](diffhunk://#diff-8b8ca185b7ae628116b8f8712611d2b02f2b5eab821545b5c55b709064c8a3bdR47)