### PR TITLE
Address linter issues

### DIFF
--- a/pkg/edge/httpserver.go
+++ b/pkg/edge/httpserver.go
@@ -66,7 +66,7 @@ func New(cfg Config, connService ConnService) (*HTTPServer, error) {
 // Accepts ctx to control the server's lifecycle and handle graceful shutdowns.
 // Returns an error if the server fails to start, listen, or encounters unexpected termination issues.
 func (s *HTTPServer) Run(ctx context.Context) error {
-	var mw []func(next http.Handler) http.Handler
+	mw := make([]func(next http.Handler) http.Handler, 0, 6)
 
 	mw = append(mw,
 		middleware.NewFishingProtection(),


### PR DESCRIPTION
This pull request makes a minor optimization to the initialization of the middleware slice in the `Run` method of the `HTTPServer`. The slice is now preallocated with a capacity of 6, which can improve performance by reducing allocations as middleware is appended.

* Performance optimization:
  * Preallocated the middleware slice `mw` with a capacity of 6 in the `Run` method of `HTTPServer` to reduce memory allocations when appending middleware. (`pkg/edge/httpserver.go`)