### PR TITLE
Potential fix for code scanning alert no. 12: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/pkg/edge/middleware/fishing_protection.go
+++ b/pkg/edge/middleware/fishing_protection.go
@@ -258,6 +258,7 @@ func handleConsentFormSubmission(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   3600 * 24, // 24 hours
 		HttpOnly: true,
 		SameSite: http.SameSiteNoneMode,
+		Secure:   true,
 	}
 	http.SetCookie(w, &cookie)
 


### PR DESCRIPTION
Potential fix for [https://github.com/ksysoev/make-it-public/security/code-scanning/12](https://github.com/ksysoev/make-it-public/security/code-scanning/12)

In general, to fix this problem every cookie that carries any security- or state-relevant information should have `Secure: true` so it is only transmitted over HTTPS. In Go, the `http.Cookie` struct defaults `Secure` to `false` unless explicitly set, so you must add `Secure: true` when constructing such cookies.

For this specific case in `pkg/edge/middleware/fishing_protection.go`, the best targeted fix is to modify the `cookie := http.Cookie{...}` literal inside `handleConsentFormSubmission` to include `Secure: true`. This does not alter existing logic or semantics aside from ensuring the cookie is only sent over HTTPS. No other fields or functions need to change, and no imports are required because `Secure` is already part of the standard `http.Cookie` type. Concretely, edit the block around lines 254–261 to add a `Secure: true,` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
