### PR TITLE
feat: increase rate limit to 32 for V2 protocol multiplexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The MIT client and server can be configured using environment variables:
 - `HTTP_PUBLIC_SCHEMA`: Public HTTP schema (http/https)
 - `HTTP_PUBLIC_DOMAIN`: Public domain name
 - `HTTP_LISTEN`: HTTP server listen address
+- `HTTP_CONN_LIMIT`: Connection limit per key (default: 4, recommended: 32 with V2 protocol multiplexing)
 - `HTTP_PROXY_PROTO`: Enable proxy protocol support (true/false)
 - `REVERSE_PROXY_LISTEN`: Reverse proxy listen address
 - `REVERSE_PROXY_CERT`: Path to TLS certificate
@@ -217,6 +218,7 @@ http:
     domain: "your-domain.com"
     port: 443
   listen: ":8080"
+  conn_limit: 32
   proxy_proto: true
 reverse_proxy:
   listen: ":8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - HTTP_PUBLIC_SCHEMA=https
       - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME:-make-it-public.dev}
       - HTTP_LISTEN=:8080
+      - HTTP_CONN_LIMIT=${HTTP_CONN_LIMIT:-32}
       - HTTP_PROXY_PROTO=true
       - REVERSE_PROXY_LISTEN=:8081
       - REVERSE_PROXY_CERT=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${DOMAIN_NAME}/${DOMAIN_NAME}.crt

--- a/runtime/config.yaml
+++ b/runtime/config.yaml
@@ -4,6 +4,7 @@ http:
     domain: "make-it-public.com"
     port: 8080
   listen: ":8080"
+  conn_limit: 32
 reverse_proxy:
   listen: ":8081"
 api:


### PR DESCRIPTION
## Summary

- Increases default connection rate limit from 4 to 32 for Docker deployments
- Adds `HTTP_CONN_LIMIT` environment variable for configuration flexibility
- Updates documentation to reflect new rate limiting options

## Motivation

With the recent introduction of V2 protocol and yamux connection multiplexing (commits 7039f07 and 1919def), the service can now handle significantly more concurrent connections per client with better resource utilization. This change increases the rate limit 8x to allow clients to use Make It Public more extensively while taking advantage of the multiplexing capabilities.

## Changes

### Configuration
- **docker-compose.yml**: Added `HTTP_CONN_LIMIT=${HTTP_CONN_LIMIT:-32}` environment variable
- **runtime/config.yaml**: Added `conn_limit: 32` to http configuration for local development reference
- **README.md**: Documented the new `HTTP_CONN_LIMIT` environment variable with context about V2 protocol

### Implementation Details
- Code default remains at 4 (unchanged in `pkg/edge/httpserver.go`)
- Docker Compose deployments now default to 32
- Can be overridden via `HTTP_CONN_LIMIT` environment variable
- DigitalOcean deployment automatically uses 32 from docker-compose.yml

## Benefits

- **Better resource utilization**: Leverages V2 protocol's yamux multiplexing
- **Increased capacity**: 8x increase allows more extensive usage
- **Flexible configuration**: Easy to adjust via environment variable
- **Backward compatible**: Code default unchanged, only deployment configuration updated

## Testing

- ✅ Verified docker-compose configuration is valid
- ✅ Environment variable correctly defaults to 32
- ✅ Can be overridden with custom values