### PR TITLE
Add Docker Swarm deployment support for CloudLab infrastructure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
             MIT_SERVER=${{ secrets.MIT_SERVER }}
             VERSION=${{ env.VERSION }}
       - if: github.ref_type == 'tag'
-        name: Deploy to DigitalOcean Droplet
+        name: Deploy to CloudLab Droplet (Docker Swarm)
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
           host: ${{secrets.HOST}}
@@ -73,13 +73,28 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           port: ${{secrets.PORT}}
           script: |
-            cd make-it-public
-            git pull
+            # Navigate to make-it-public repository
+            cd ~/make-it-public
+            
+            # Update repository
+            git fetch --all
+            git checkout ${{ env.VERSION }}
+            git pull origin ${{ env.VERSION }} || true
+            
+            # Export environment variables
             export MIT_VERSION=${{ env.VERSION }}
-            docker compose pull
             export CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }}
             export EMAIL=${{ secrets.EMAIL }}
             export DOMAIN_NAME=${{ secrets.DOMAIN_NAME }}
             export AUTH_SALT=${{ secrets.AUTH_SALT }}
-            export NETWORK_NAME=${{ env.MIT_NETWORK }}
-            docker stack deploy -c docker-compose.yml makeitpublic
+            
+            # Ensure cloudlab-public network exists
+            docker network inspect cloudlab-public >/dev/null 2>&1 || \
+              docker network create --driver overlay --attachable cloudlab-public
+            
+            # Deploy stack to Docker Swarm
+            docker stack deploy -c docker-stack.yml makeitpublic
+            
+            # Show deployment status
+            echo "Deployment completed. Stack status:"
+            docker stack services makeitpublic

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ services:
 
 ### Running as a Docker Container
 
-The easiest way to run the MIT server is using Docker Compose:
+#### Option 1: Docker Compose (Standalone)
+
+For standalone deployment, use Docker Compose:
 
 ```bash
 # Clone the repository
@@ -154,6 +156,38 @@ docker-compose up -d
 
 This will start the MIT server along with Redis for authentication and Caddy as a reverse proxy.
 
+#### Option 2: Docker Swarm (Production)
+
+For production deployments with Docker Swarm:
+
+```bash
+# Clone the repository
+git clone https://github.com/ksysoev/make-it-public.git
+cd make-it-public
+
+# Set up environment variables
+export DOMAIN_NAME=your-domain.com
+export AUTH_SALT=your-random-salt
+export CLOUDFLARE_API_TOKEN=your-cloudflare-token
+export EMAIL=your-email@example.com
+export MIT_VERSION=latest  # or specific version tag
+
+# Ensure cloudlab-public network exists
+docker network create --driver overlay --attachable cloudlab-public
+
+# Deploy using the helper script
+./deploy-swarm.sh
+
+# Or deploy manually
+docker stack deploy -c docker-stack.yml makeitpublic
+```
+
+**Docker Swarm Deployment Notes:**
+- The stack uses the `cloudlab-public` overlay network for service communication
+- Caddy uses `mode: host` for port binding to support Let's Encrypt HTTP/TLS-ALPN challenges
+- All services are constrained to manager nodes for simplicity
+- Persistent volumes are used for Redis data and Caddy certificates
+
 #### Running the Server Manually
 
 You can also run the server manually:
@@ -171,6 +205,12 @@ mit server token generate --key-id your-key-id --ttl 24
 ```
 
 This will generate a token that is valid for 24 hours.
+
+#### Deployment Files
+
+- **`docker-compose.yml`**: For standalone Docker Compose deployments
+- **`docker-stack.yml`**: For Docker Swarm deployments (production)
+- **`deploy-swarm.sh`**: Helper script for deploying to Docker Swarm
 
 ---
 

--- a/deploy-swarm.sh
+++ b/deploy-swarm.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# Make It Public - Docker Swarm Deployment Script
+# This script deploys the make-it-public stack to a Docker Swarm cluster
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running in a Swarm
+if ! docker info 2>/dev/null | grep -q "Swarm: active"; then
+    print_error "Docker Swarm is not active. Please initialize or join a swarm first."
+    exit 1
+fi
+
+# Check required environment variables
+REQUIRED_VARS=("DOMAIN_NAME" "EMAIL" "CLOUDFLARE_API_TOKEN" "AUTH_SALT")
+MISSING_VARS=()
+
+for var in "${REQUIRED_VARS[@]}"; do
+    if [ -z "${!var}" ]; then
+        MISSING_VARS+=("$var")
+    fi
+done
+
+if [ ${#MISSING_VARS[@]} -gt 0 ]; then
+    print_error "Missing required environment variables:"
+    for var in "${MISSING_VARS[@]}"; do
+        echo "  - $var"
+    done
+    echo ""
+    echo "Usage:"
+    echo "  export DOMAIN_NAME=your-domain.com"
+    echo "  export EMAIL=your-email@example.com"
+    echo "  export CLOUDFLARE_API_TOKEN=your-cloudflare-token"
+    echo "  export AUTH_SALT=your-random-salt"
+    echo "  export MIT_VERSION=v1.0.0  # optional, defaults to 'latest'"
+    echo ""
+    echo "  ./deploy-swarm.sh"
+    exit 1
+fi
+
+# Set default version if not provided
+MIT_VERSION=${MIT_VERSION:-latest}
+
+# Check if cloudlab-public network exists
+if ! docker network inspect cloudlab-public >/dev/null 2>&1; then
+    print_warn "Network 'cloudlab-public' does not exist. Creating it..."
+    docker network create --driver overlay --attachable cloudlab-public
+    print_info "Network 'cloudlab-public' created."
+fi
+
+# Display configuration
+print_info "Deploying Make It Public to Docker Swarm"
+echo "  Domain:  $DOMAIN_NAME"
+echo "  Email:   $EMAIL"
+echo "  Version: $MIT_VERSION"
+echo ""
+
+# Deploy the stack
+print_info "Deploying stack 'makeitpublic'..."
+docker stack deploy -c docker-stack.yml makeitpublic
+
+# Wait a moment for services to initialize
+sleep 3
+
+# Show service status
+print_info "Deployment completed. Current service status:"
+docker stack services makeitpublic
+
+echo ""
+print_info "Deployment commands:"
+echo "  Check services:  docker stack services makeitpublic"
+echo "  View logs:       docker service logs makeitpublic_mitserver -f"
+echo "  Remove stack:    docker stack rm makeitpublic"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,129 @@
+version: '3.8'
+
+services:
+  redis:
+    image: docker.io/bitnami/redis:7.4.2
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - redis_data:/bitnami/redis/data
+    networks:
+      - cloudlab-public
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints:
+          - node.role == manager
+
+  mitserver:
+    image: "ghcr.io/ksysoev/make-it-public:${MIT_VERSION:-latest}"
+    environment:
+      - AUTH_REDIS_ADDR=redis:6379
+      - AUTH_SALT=${AUTH_SALT:-someRandomSalt}
+      - "AUTH_KEY_PREFIX=MIT::"
+      - HTTP_PUBLIC_SCHEMA=https
+      - HTTP_PUBLIC_DOMAIN=${DOMAIN_NAME:-make-it-public.dev}
+      - HTTP_LISTEN=:8080
+      - HTTP_CONN_LIMIT=${HTTP_CONN_LIMIT:-32}
+      - HTTP_PROXY_PROTO=true
+      - REVERSE_PROXY_LISTEN=:8081
+      - REVERSE_PROXY_CERT=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${DOMAIN_NAME}/${DOMAIN_NAME}.crt
+      - REVERSE_PROXY_KEY=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${DOMAIN_NAME}/${DOMAIN_NAME}.key
+      - API_LISTEN=:8082
+      - LOG_LEVEL=info
+      - LOG_TEXT=false
+    command: ["server", "run", "all"]
+    volumes:
+      - caddy_data:/data:ro
+    networks:
+      - cloudlab-public
+    ports:
+      - target: 8080
+        published: 8080
+        protocol: tcp
+      - target: 8081
+        published: 8081
+        protocol: tcp
+      - target: 8082
+        published: 8082
+        protocol: tcp
+    healthcheck:
+      test: ["/mit", "server", "check"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints:
+          - node.role == manager
+    depends_on:
+      - redis
+
+  caddy:
+    image: ghcr.io/caddybuilds/caddy-cloudflare:2.10-alpine
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: udp
+        mode: host
+    environment:
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - EMAIL=${EMAIL}
+      - DOMAIN_NAME=${DOMAIN_NAME}
+    volumes:
+      - type: bind
+        source: ./runtime/Caddyfile
+        target: /etc/caddy/Caddyfile
+        read_only: true
+      - type: bind
+        source: ./static
+        target: /srv
+        read_only: true
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - cloudlab-public
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 256M
+    depends_on:
+      - mitserver
+
+volumes:
+  caddy_data:
+  caddy_config:
+  redis_data:
+
+networks:
+  cloudlab-public:
+    external: true


### PR DESCRIPTION
## Summary

This PR adds Docker Swarm deployment support to enable deploying make-it-public on CloudLab infrastructure, while maintaining backward compatibility with standalone Docker Compose deployments.

## Changes

### New Files
- **`docker-stack.yml`**: Docker Swarm stack configuration
  - Uses `cloudlab-public` overlay network for service communication
  - Configures proper deployment constraints (manager nodes only)
  - Uses `mode: host` for Caddy to support Let's Encrypt HTTP/TLS-ALPN challenges
  - Adds health checks and resource limits
  
- **`deploy-swarm.sh`**: Helper script for manual Swarm deployments
  - Validates required environment variables
  - Checks Swarm status
  - Creates cloudlab-public network if needed
  - Provides deployment status and useful commands

### Modified Files
- **`.github/workflows/docker.yml`**: Updated deployment workflow
  - Changed deployment target to CloudLab droplet
  - Switched from `docker compose` to `docker stack deploy`
  - Deploys from `~/make-it-public` repository on the droplet
  - Automatically creates cloudlab-public network if missing
  
- **`README.md`**: Added Docker Swarm deployment documentation
  - Added "Option 2: Docker Swarm (Production)" section
  - Documented deployment prerequisites and steps
  - Added deployment files reference section

## Key Features

✅ **Backward Compatible**: Existing `docker-compose.yml` remains unchanged for standalone deployments
✅ **Production Ready**: Swarm configuration follows best practices with health checks and restart policies
✅ **Network Integration**: Uses cloudlab-public overlay network for multi-stack deployments
✅ **Automated Deployment**: GitHub Actions automatically deploys on tag push
✅ **Manual Deployment**: Helper script for easy manual deployments

## Deployment Architecture

The services are deployed as a Docker Swarm stack with:
- **Redis**: Persistent storage for authentication tokens
- **MITServer**: Main application server (ports 8080, 8081, 8082)
- **Caddy**: Reverse proxy with automatic SSL/TLS (Cloudflare DNS challenge)

All services communicate via the `cloudlab-public` overlay network, allowing integration with other services on the same Swarm cluster.

## Testing Checklist

- [ ] GitHub Actions workflow builds successfully
- [ ] Manual deployment with deploy-swarm.sh script works
- [ ] Services start and pass health checks
- [ ] Caddy obtains SSL certificates successfully
- [ ] Client connections work through the reverse proxy
- [ ] Existing docker-compose.yml deployment still works

## Required Secrets (no changes)

The following GitHub secrets are required (same as before):
- `HOST`: CloudLab droplet IP
- `USERNAME`: SSH username (deployer)
- `SSH_KEY`: SSH private key
- `PORT`: SSH port (1923)
- `CLOUDFLARE_API_TOKEN`: Cloudflare API token
- `EMAIL`: Email for Let's Encrypt
- `DOMAIN_NAME`: Domain name for the service
- `AUTH_SALT`: Salt for token generation
- `MIT_SERVER`: Server address for client builds

## Deployment Prerequisites

On the CloudLab droplet, ensure:
1. Docker Swarm is initialized
2. The repository is cloned to `~/make-it-public`
3. The cloudlab-public network exists (workflow creates it automatically)
4. Ports 80, 443 (TCP/UDP), 8080, 8081, 8082 are open in the firewall

## Next Steps

After merge, to deploy:
1. Create a new version tag (e.g., `v1.2.3`)
2. Push the tag: `git push origin v1.2.3`
3. GitHub Actions will automatically deploy to the CloudLab droplet
4. Monitor deployment: `docker stack services makeitpublic`