### PR TITLE
feat: replace local Redis container with external REDIS_URL secret

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -134,5 +134,6 @@ jobs:
           "AUTH_SALT": "${{ secrets.AUTH_SALT }}",
           "DOMAIN_NAME": "${{ secrets.DOMAIN_NAME }}",
           "EMAIL": "${{ secrets.EMAIL }}",
-          "CLOUDFLARE_API_TOKEN": "${{ secrets.CLOUDFLARE_API_TOKEN }}"
+          "CLOUDFLARE_API_TOKEN": "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+          "REDIS_URL": "${{ secrets.REDIS_URL }}"
         }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,24 +3,10 @@
 # Configuration files are embedded in Docker images (no volume mounts from host)
 
 services:
-  redis:
-    image: redis:7.4-alpine
-    command: redis-server --appendonly yes
-    volumes:
-      - redis_data:/data
-    networks:
-      - backend
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
-        delay: 5s
-        max_attempts: 3
-
   mitserver:
     image: "ghcr.io/ksysoev/make-it-public:${MIT_VERSION:-latest}"
     environment:
-      - AUTH_REDIS_ADDR=redis:6379
+      - AUTH_REDIS_URL=${REDIS_URL}
       - AUTH_SALT=${AUTH_SALT}
       - "AUTH_KEY_PREFIX=MIT::"
       - HTTP_PUBLIC_SCHEMA=https
@@ -54,8 +40,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    depends_on:
-      - redis
     deploy:
       replicas: 1
       restart_policy:
@@ -118,7 +102,6 @@ services:
 volumes:
   caddy_data:
   caddy_config:
-  redis_data:
 
 networks:
   # Service-specific backend network for internal communication

--- a/pkg/repo/auth/auth.go
+++ b/pkg/repo/auth/auth.go
@@ -18,6 +18,7 @@ const (
 )
 
 type Config struct {
+	RedisURL  string `mapstructure:"redis_url"`
 	RedisAddr string `mapstructure:"redis_addr"`
 	Password  string `mapstructure:"redis_password"` // #nosec G117 -- This is a config field name, not an exposed password
 	KeyPrefix string `mapstructure:"key_prefix"`
@@ -41,12 +42,24 @@ type Repo struct {
 
 // New creates and initializes a new Repo instance with the provided configuration.
 // It sets up a Redis client using the given Redis address, password, and key prefix from the Config struct.
+// If RedisURL is set it takes precedence over RedisAddr/Password.
 // Returns a pointer to the initialized Repo. Assumes valid Config is provided and may panic on misconfiguration.
 func New(cfg *Config) *Repo {
-	rdb := redis.NewClient(&redis.Options{
-		Addr:     cfg.RedisAddr,
-		Password: cfg.Password,
-	})
+	var opts *redis.Options
+
+	if cfg.RedisURL != "" {
+		var err error
+		if opts, err = redis.ParseURL(cfg.RedisURL); err != nil {
+			panic(fmt.Sprintf("invalid redis_url: %v", err))
+		}
+	} else {
+		opts = &redis.Options{
+			Addr:     cfg.RedisAddr,
+			Password: cfg.Password,
+		}
+	}
+
+	rdb := redis.NewClient(opts)
 
 	return &Repo{
 		db:        rdb,


### PR DESCRIPTION
## Summary

Removes the self-hosted Redis container from the production deployment and switches to an external Redis instance configured via a GitHub secret.

## Changes

### `pkg/repo/auth/auth.go`
- Added `RedisURL string` field (`mapstructure:"redis_url"`) to `Config`
- Updated `New()` to call `redis.ParseURL()` when `RedisURL` is set, falling back to `RedisAddr`/`Password` — fully backward-compatible

### `deploy/docker-compose.yml`
- Removed the `redis` service
- Removed the `redis_data` volume
- Removed `depends_on: redis` from `mitserver`
- Replaced `AUTH_REDIS_ADDR=redis:6379` with `AUTH_REDIS_URL=${REDIS_URL}`

### `.github/workflows/docker.yml`
- Added `REDIS_URL: ${{ secrets.REDIS_URL }}` to `deployment_secrets`

## Prerequisites
Make sure the `REDIS_URL` secret is set in **GitHub → Settings → Secrets → Actions → production environment** using the standard Redis URL format:
```
redis://:password@host:6379
# or for TLS:
rediss://:password@host:6379
```